### PR TITLE
Fix AnnotationTargetSupport#getMetaAnnotated

### DIFF
--- a/src/main/java/org/hibernate/models/internal/AnnotationTargetSupport.java
+++ b/src/main/java/org/hibernate/models/internal/AnnotationTargetSupport.java
@@ -118,7 +118,7 @@ public interface AnnotationTargetSupport extends MutableAnnotationTarget {
 	default <A extends Annotation> List<AnnotationUsage<? extends Annotation>> getMetaAnnotated(Class<A> metaAnnotationType) {
 		final List<AnnotationUsage<?>> usages = new ArrayList<>();
 		forAllAnnotationUsages( (usage) -> {
-			final AnnotationUsage<? extends Annotation> metaUsage = usage.getAnnotationDescriptor().getAnnotationUsage( metaAnnotationType );
+			final Annotation metaUsage = usage.getAnnotationType().getAnnotation( metaAnnotationType );
 			if ( metaUsage != null ) {
 				usages.add( usage );
 			}


### PR DESCRIPTION
Not sure the proposed change is correct but I noticed that an annotation like `@Comment` 
```
@TypeBinderType(binder = CommentBinder.class)
...
public @interface Comment {
```
was not returned by`getMetaAnnotated( TypeBinderType.class )`