### PR TITLE
Fix annotation default values extraction

### DIFF
--- a/src/main/java/org/hibernate/models/spi/AnnotationDescriptor.java
+++ b/src/main/java/org/hibernate/models/spi/AnnotationDescriptor.java
@@ -88,10 +88,12 @@ public interface AnnotationDescriptor<A extends Annotation> extends AnnotationTa
 	 * @param context Access to needed services
 	 */
 	default MutableAnnotationUsage<A> createUsage(AnnotationTarget target, SourceModelBuildingContext context) {
-		final DynamicAnnotationUsage<A> usage = new DynamicAnnotationUsage<>( this, target );
+		final DynamicAnnotationUsage<A> usage = new DynamicAnnotationUsage<>( this, target, context );
 		getAttributes().forEach( (attr) -> {
 			final Object value = attr.getTypeDescriptor().createValue( attr, target, context );
-			usage.setAttributeValue( attr.getName(), value );
+			if ( value != null ) {
+				usage.setAttributeValue( attr.getName(), value );
+			}
 		} );
 		return usage;
 	}

--- a/src/test/java/org/hibernate/models/annotations/DynamicAnnotationTests.java
+++ b/src/test/java/org/hibernate/models/annotations/DynamicAnnotationTests.java
@@ -7,6 +7,8 @@
 
 package org.hibernate.models.annotations;
 
+import java.util.List;
+
 import org.hibernate.models.UnknownAnnotationAttributeException;
 import org.hibernate.models.internal.SourceModelBuildingContextImpl;
 import org.hibernate.models.internal.dynamic.DynamicAnnotationUsage;
@@ -15,6 +17,10 @@ import org.hibernate.models.orm.JpaAnnotations;
 
 import org.junit.jupiter.api.Test;
 
+import jakarta.persistence.ConstraintMode;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.JoinTable;
 import jakarta.persistence.SequenceGenerator;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,7 +37,8 @@ public class DynamicAnnotationTests {
 		final DynamicClassDetails dynamicEntity = new DynamicClassDetails( "DynamicEntity", buildingContext );
 		final DynamicAnnotationUsage<SequenceGenerator> generatorAnn = new DynamicAnnotationUsage<>(
 				JpaAnnotations.SEQUENCE_GENERATOR,
-				dynamicEntity
+				dynamicEntity,
+				buildingContext
 		);
 		assertThat( generatorAnn.getString( "name" ) ).isEqualTo( "" );
 		assertThat( generatorAnn.getString( "sequenceName" ) ).isEqualTo( "" );
@@ -48,5 +55,59 @@ public class DynamicAnnotationTests {
 			// ignore
 		}
 
+	}
+
+	@Test
+	void testJoinTableForeignKeyDefaultValue() {
+		final SourceModelBuildingContextImpl buildingContext = createBuildingContext();
+		final DynamicClassDetails dynamicEntity = new DynamicClassDetails( "DynamicEntity", buildingContext );
+		final DynamicAnnotationUsage<JoinTable> generatorAnn = new DynamicAnnotationUsage<>(
+				JpaAnnotations.JOIN_TABLE,
+				dynamicEntity,
+				buildingContext
+		);
+
+		final Object foreignKey = generatorAnn.getAttributeValue( "foreignKey" );
+
+		assertThat( foreignKey ).isInstanceOf( DynamicAnnotationUsage.class );
+
+		final DynamicAnnotationUsage foreignKeyAnnotationUsage = (DynamicAnnotationUsage) foreignKey;
+
+		assertThat( foreignKeyAnnotationUsage.getAttributeValue( "value" ) ).isEqualTo( ConstraintMode.PROVIDER_DEFAULT );
+
+		assertThat( foreignKeyAnnotationUsage.getAttributeValue( "name" )).isEqualTo( "" );
+		assertThat( foreignKeyAnnotationUsage.getAttributeValue( "options" )).isEqualTo( "" );
+		assertThat( foreignKeyAnnotationUsage.getAttributeValue( "foreignKeyDefinition" )).isEqualTo( "" );
+	}
+
+	@Test
+	void testDefaultArrayValue() {
+		final SourceModelBuildingContextImpl buildingContext = createBuildingContext();
+		final DynamicClassDetails dynamicEntity = new DynamicClassDetails( "DynamicEntity", buildingContext );
+		final DynamicAnnotationUsage<JoinTable> generatorAnn = new DynamicAnnotationUsage<>(
+				JpaAnnotations.JOIN_TABLE,
+				dynamicEntity,
+				buildingContext
+		);
+
+		final Object joinColumns = generatorAnn.getAttributeValue( "joinColumns" );
+		assertThat( joinColumns ).isInstanceOf( List.class );
+
+	}
+
+	@Test
+	void testDefaultValues() {
+		final SourceModelBuildingContextImpl buildingContext = createBuildingContext();
+		final DynamicClassDetails dynamicEntity = new DynamicClassDetails( "DynamicEntity", buildingContext );
+		final DynamicAnnotationUsage<GeneratedValue> generatorAnn = new DynamicAnnotationUsage<>(
+				JpaAnnotations.GENERATED_VALUE,
+				dynamicEntity,
+				buildingContext
+		);
+
+		GenerationType strategy = generatorAnn.getAttributeValue( "strategy" );
+		assertThat( strategy ).isEqualTo( GenerationType.AUTO );
+		String generator = generatorAnn.findAttributeValue( "generator" );
+		assertThat( generator ).isEqualTo( "" );
 	}
 }


### PR DESCRIPTION
in case of 
```
public @interface JoinTable {
   ....
    ForeignKey inverseForeignKey() default @ForeignKey(ConstraintMode.PROVIDER_DEFAULT);
  ...
}
```

the value returned by `getAttributeMethod().getDefaultValue()` is an instance of `Annotation`, so we need to convert it in a DynaicAnnotationUsage.

When the default value is a multi value 
```
JoinColumn[] joinColumns() default {};
```
the value returned by `getAttributeMethod().getDefaultValue()`  is an array but we later try to acces it as a list,
`List<E> AttributeUsage#getList(String name);`
