### PR TITLE
TypeDetails Object should be resolved if type Kind is CLASS

### DIFF
--- a/src/main/java/org/hibernate/models/internal/IsBoundTypeSwitch.java
+++ b/src/main/java/org/hibernate/models/internal/IsBoundTypeSwitch.java
@@ -1,0 +1,23 @@
+/*
+ * Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.models.internal;
+
+import java.util.Objects;
+
+import org.hibernate.models.spi.ClassDetails;
+import org.hibernate.models.spi.ClassTypeDetails;
+import org.hibernate.models.spi.SourceModelBuildingContext;
+
+public class IsBoundTypeSwitch extends IsResolvedTypeSwitch{
+	public static final IsBoundTypeSwitch IS_BOUND_SWITCH = new IsBoundTypeSwitch();
+
+	@Override
+	public Boolean caseClass(ClassTypeDetails classType, SourceModelBuildingContext buildingContext) {
+		// not completely kosher, but works for our needs
+		return !Objects.equals( classType.getClassDetails(), ClassDetails.OBJECT_CLASS_DETAILS );
+	}
+}

--- a/src/main/java/org/hibernate/models/internal/IsResolvedTypeSwitch.java
+++ b/src/main/java/org/hibernate/models/internal/IsResolvedTypeSwitch.java
@@ -23,6 +23,8 @@ import org.hibernate.models.spi.TypeVariableReferenceDetails;
 import org.hibernate.models.spi.VoidTypeDetails;
 import org.hibernate.models.spi.WildcardTypeDetails;
 
+import static org.hibernate.models.internal.IsBoundTypeSwitch.IS_BOUND_SWITCH;
+
 /**
  * TypeDetailsSwitch implementation checking whether a type is resolved (all of its bounds are known)
  *
@@ -31,17 +33,12 @@ import org.hibernate.models.spi.WildcardTypeDetails;
 public class IsResolvedTypeSwitch implements TypeDetailsSwitch<Boolean> {
 	public static final IsResolvedTypeSwitch IS_RESOLVED_SWITCH = new IsResolvedTypeSwitch();
 
-	public static boolean isBound(TypeDetails typeDetails, SourceModelBuildingContext buildingContext) {
-		return TypeDetailsSwitch.switchType( typeDetails, IS_RESOLVED_SWITCH, buildingContext );
+	private static boolean isBound(TypeDetails typeDetails, SourceModelBuildingContext buildingContext) {
+		return TypeDetailsSwitch.switchType( typeDetails, IS_BOUND_SWITCH, buildingContext );
 	}
 
 	@Override
 	public Boolean caseClass(ClassTypeDetails classType, SourceModelBuildingContext buildingContext) {
-		// not completely kosher, but works for our needs
-		//noinspection RedundantIfStatement
-		if ( Objects.equals( classType.getClassDetails(), ClassDetails.OBJECT_CLASS_DETAILS ) ) {
-			return false;
-		}
 		return true;
 	}
 

--- a/src/test/java/org/hibernate/models/generics/InheritanceTypeVariableTests.java
+++ b/src/test/java/org/hibernate/models/generics/InheritanceTypeVariableTests.java
@@ -72,8 +72,8 @@ public class InheritanceTypeVariableTests {
 			assertThat( bound.asClassType().getClassDetails().toJavaClass() ).isEqualTo( Object.class );
 
 			final ClassBasedTypeDetails resolvedClassType = idField.resolveRelativeClassType( rootClassDetails );
+			assertThat( idField.getType().isResolved() ).isFalse();
 			assertThat( resolvedClassType.getClassDetails().toJavaClass() ).isEqualTo( Object.class );
-			assertThat( resolvedClassType.isResolved() ).isFalse();
 		}
 
 		{


### PR DESCRIPTION
Not sure this is the correct solution but it fixes the case
```
@Entity(name = "AnEntity")
class AnEntity {
      EmbeddableWithParent embeddableWithParent;
}

@Embeddable
class EmbeddableWithParent {
      @Parent
	private Object parent;
}
```
where the Property EmbeddableWithParent.parent is considered an unbound type.
	` 