### PR TITLE
Remove `AnnotationUsage#getAnnotationTarget`

### DIFF
--- a/src/main/java/org/hibernate/models/internal/AbstractTypeDescriptor.java
+++ b/src/main/java/org/hibernate/models/internal/AbstractTypeDescriptor.java
@@ -41,7 +41,7 @@ public abstract class AbstractTypeDescriptor<V> implements ValueTypeDescriptor<V
 
 		//noinspection unchecked
 		final ValueWrapper<V, Object> valueWrapper = (ValueWrapper<V, Object>) createJdkWrapper( context );
-		return valueWrapper.wrap( defaultValue, target, context );
+		return valueWrapper.wrap( defaultValue, context );
 	}
 
 	@Override

--- a/src/main/java/org/hibernate/models/internal/ArrayTypeDescriptor.java
+++ b/src/main/java/org/hibernate/models/internal/ArrayTypeDescriptor.java
@@ -62,7 +62,7 @@ public class ArrayTypeDescriptor<V> implements ValueTypeDescriptor<List<V>> {
 			return Collections.emptyList();
 		}
 
-		return jdkValueWrapper.wrap( defaultValue, target, context );
+		return jdkValueWrapper.wrap( defaultValue, context );
 	}
 
 	@Override

--- a/src/main/java/org/hibernate/models/internal/jandex/AbstractAnnotationTarget.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/AbstractAnnotationTarget.java
@@ -34,7 +34,7 @@ public abstract class AbstractAnnotationTarget implements AnnotationTargetSuppor
 	@Override
 	public Map<Class<? extends Annotation>, AnnotationUsage<?>> getUsageMap() {
 		if ( usageMap == null ) {
-			usageMap = AnnotationUsageBuilder.collectUsages( getJandexAnnotationTarget(), this, buildingContext );
+			usageMap = AnnotationUsageBuilder.collectUsages( getJandexAnnotationTarget(), buildingContext );
 		}
 		return usageMap;
 	}

--- a/src/main/java/org/hibernate/models/internal/jandex/AbstractValueExtractor.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/AbstractValueExtractor.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.models.spi.ValueExtractor;
 
@@ -18,20 +17,16 @@ import org.jboss.jandex.AnnotationValue;
  */
 public abstract class AbstractValueExtractor<W> implements ValueExtractor<AnnotationInstance,W> {
 
-	protected abstract W extractAndWrap(
-			AnnotationValue jandexValue,
-			AnnotationTarget target,
-			SourceModelBuildingContext buildingContext);
+	protected abstract W extractAndWrap(AnnotationValue jandexValue, SourceModelBuildingContext buildingContext);
 
 	@Override
 	public W extractValue(
 			AnnotationInstance annotation,
 			String attributeName,
-			AnnotationTarget target,
 			SourceModelBuildingContext buildingContext) {
 		final AnnotationValue jandexValue = resolveAnnotationValue( annotation, attributeName, buildingContext );
 		assert jandexValue != null;
-		return extractAndWrap( jandexValue, target, buildingContext );
+		return extractAndWrap( jandexValue, buildingContext );
 	}
 
 	protected AnnotationValue resolveAnnotationValue(

--- a/src/main/java/org/hibernate/models/internal/jandex/AnnotationUsageBuilder.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/AnnotationUsageBuilder.java
@@ -21,7 +21,6 @@ import java.util.function.BiConsumer;
 import org.hibernate.models.internal.util.CollectionHelper;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.AnnotationDescriptorRegistry;
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.AnnotationUsage;
 import org.hibernate.models.spi.AttributeDescriptor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
@@ -47,7 +46,6 @@ public class AnnotationUsageBuilder {
 	 */
 	public static Map<Class<? extends Annotation>, AnnotationUsage<?>> collectUsages(
 			org.jboss.jandex.AnnotationTarget jandexAnnotationTarget,
-			AnnotationTarget target,
 			SourceModelBuildingContext buildingContext) {
 		if ( jandexAnnotationTarget == null ) {
 			return Collections.emptyMap();
@@ -55,7 +53,6 @@ public class AnnotationUsageBuilder {
 		final Map<Class<? extends Annotation>, AnnotationUsage<?>> result = new HashMap<>();
 		processAnnotations(
 				jandexAnnotationTarget.declaredAnnotations(),
-				target,
 				result::put,
 				buildingContext
 		);
@@ -67,7 +64,6 @@ public class AnnotationUsageBuilder {
 	 */
 	public static void processAnnotations(
 			Collection<AnnotationInstance> annotations,
-			AnnotationTarget target,
 			BiConsumer<Class<? extends Annotation>, AnnotationUsage<?>> consumer,
 			SourceModelBuildingContext buildingContext) {
 		final AnnotationDescriptorRegistry annotationDescriptorRegistry = buildingContext.getAnnotationDescriptorRegistry();
@@ -88,7 +84,6 @@ public class AnnotationUsageBuilder {
 			final AnnotationUsage<?> usage = makeUsage(
 					annotation,
 					annotationDescriptor,
-					target,
 					buildingContext
 			);
 			consumer.accept( annotationType, usage );
@@ -98,9 +93,8 @@ public class AnnotationUsageBuilder {
 	public static <A extends Annotation> AnnotationUsage<A> makeUsage(
 			AnnotationInstance annotation,
 			AnnotationDescriptor<A> annotationDescriptor,
-			AnnotationTarget target,
 			SourceModelBuildingContext buildingContext) {
-		return new JandexAnnotationUsage<>( annotation, annotationDescriptor, target, buildingContext );
+		return new JandexAnnotationUsage<>( annotation, annotationDescriptor, buildingContext );
 	}
 
 	/**
@@ -110,7 +104,6 @@ public class AnnotationUsageBuilder {
 	public static <A extends Annotation> Map<String,?> extractAttributeValues(
 			AnnotationInstance annotationInstance,
 			AnnotationDescriptor<A> annotationDescriptor,
-			AnnotationTarget target,
 			SourceModelBuildingContext buildingContext) {
 		if ( CollectionHelper.isEmpty( annotationDescriptor.getAttributes() ) ) {
 			return Collections.emptyMap();
@@ -122,7 +115,7 @@ public class AnnotationUsageBuilder {
 			final ValueExtractor<AnnotationInstance, ?> extractor = attributeDescriptor
 					.getTypeDescriptor()
 					.createJandexExtractor( buildingContext );
-			final Object attributeValue = extractor.extractValue( annotationInstance, attributeDescriptor, target, buildingContext );
+			final Object attributeValue = extractor.extractValue( annotationInstance, attributeDescriptor, buildingContext );
 			valueMap.put( attributeDescriptor.getName(), attributeValue );
 		}
 		return valueMap;

--- a/src/main/java/org/hibernate/models/internal/jandex/ArrayValueExtractor.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/ArrayValueExtractor.java
@@ -8,7 +8,6 @@ package org.hibernate.models.internal.jandex;
 
 import java.util.List;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.models.spi.ValueWrapper;
 
@@ -25,15 +24,12 @@ public class ArrayValueExtractor<V> extends AbstractValueExtractor<List<V>> {
 	}
 
 	@Override
-	protected List<V> extractAndWrap(
-			AnnotationValue jandexValue,
-			AnnotationTarget target,
-			SourceModelBuildingContext buildingContext) {
+	protected List<V> extractAndWrap(AnnotationValue jandexValue, SourceModelBuildingContext buildingContext) {
 		assert jandexValue != null;
 
 		final List<AnnotationValue> values = jandexValue.asArrayList();
 		assert values != null;
 
-		return wrapper.wrap( jandexValue, target, buildingContext );
+		return wrapper.wrap( jandexValue, buildingContext );
 	}
 }

--- a/src/main/java/org/hibernate/models/internal/jandex/ArrayValueWrapper.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/ArrayValueWrapper.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.models.spi.ValueWrapper;
 
@@ -27,7 +26,7 @@ public class ArrayValueWrapper<V> implements ValueWrapper<List<V>,AnnotationValu
 	}
 
 	@Override
-	public List<V> wrap(AnnotationValue rawValue, AnnotationTarget target, SourceModelBuildingContext buildingContext) {
+	public List<V> wrap(AnnotationValue rawValue, SourceModelBuildingContext buildingContext) {
 		assert rawValue != null;
 
 		final List<AnnotationValue> values = rawValue.asArrayList();
@@ -38,12 +37,12 @@ public class ArrayValueWrapper<V> implements ValueWrapper<List<V>,AnnotationValu
 		}
 
 		if ( values.size() == 1 ) {
-			return Collections.singletonList( elementWrapper.wrap( values.get(0), target, buildingContext ) );
+			return Collections.singletonList( elementWrapper.wrap( values.get(0), buildingContext ) );
 		}
 
 		final List<V> results = new ArrayList<>( values.size() );
 		values.forEach( (value) -> {
-			results.add( elementWrapper.wrap( value, target, buildingContext ) );
+			results.add( elementWrapper.wrap( value, buildingContext ) );
 		} );
 		return results;
 	}

--- a/src/main/java/org/hibernate/models/internal/jandex/BooleanValueExtractor.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/BooleanValueExtractor.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
 import org.jboss.jandex.AnnotationValue;
@@ -20,11 +19,8 @@ public class BooleanValueExtractor extends AbstractValueExtractor<Boolean> {
 	public static final BooleanValueExtractor JANDEX_BOOLEAN_EXTRACTOR = new BooleanValueExtractor();
 
 	@Override
-	protected Boolean extractAndWrap(
-			AnnotationValue jandexValue,
-			AnnotationTarget target,
-			SourceModelBuildingContext buildingContext) {
+	protected Boolean extractAndWrap(AnnotationValue jandexValue, SourceModelBuildingContext buildingContext) {
 		assert jandexValue != null;
-		return BooleanValueWrapper.JANDEX_BOOLEAN_VALUE_WRAPPER.wrap( jandexValue, target, buildingContext );
+		return BooleanValueWrapper.JANDEX_BOOLEAN_VALUE_WRAPPER.wrap( jandexValue, buildingContext );
 	}
 }

--- a/src/main/java/org/hibernate/models/internal/jandex/BooleanValueWrapper.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/BooleanValueWrapper.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.models.spi.ValueWrapper;
 
@@ -21,7 +20,7 @@ public class BooleanValueWrapper implements ValueWrapper<Boolean, AnnotationValu
 	public static final BooleanValueWrapper JANDEX_BOOLEAN_VALUE_WRAPPER = new BooleanValueWrapper();
 
 	@Override
-	public Boolean wrap(AnnotationValue rawValue, AnnotationTarget target, SourceModelBuildingContext buildingContext) {
+	public Boolean wrap(AnnotationValue rawValue, SourceModelBuildingContext buildingContext) {
 		assert rawValue != null;
 		return rawValue.asBoolean();
 	}

--- a/src/main/java/org/hibernate/models/internal/jandex/ByteValueExtractor.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/ByteValueExtractor.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
 import org.jboss.jandex.AnnotationValue;
@@ -20,11 +19,8 @@ public class ByteValueExtractor extends AbstractValueExtractor<Byte> {
 	public static final ByteValueExtractor JANDEX_BYTE_EXTRACTOR = new ByteValueExtractor();
 
 	@Override
-	protected Byte extractAndWrap(
-			AnnotationValue jandexValue,
-			AnnotationTarget target,
-			SourceModelBuildingContext buildingContext) {
+	protected Byte extractAndWrap(AnnotationValue jandexValue, SourceModelBuildingContext buildingContext) {
 		assert jandexValue != null;
-		return ByteValueWrapper.JANDEX_BYTE_VALUE_WRAPPER.wrap( jandexValue, target, buildingContext );
+		return ByteValueWrapper.JANDEX_BYTE_VALUE_WRAPPER.wrap( jandexValue, buildingContext );
 	}
 }

--- a/src/main/java/org/hibernate/models/internal/jandex/ByteValueWrapper.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/ByteValueWrapper.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.models.spi.ValueWrapper;
 
@@ -21,7 +20,7 @@ public class ByteValueWrapper implements ValueWrapper<Byte, AnnotationValue> {
 	public static final ByteValueWrapper JANDEX_BYTE_VALUE_WRAPPER = new ByteValueWrapper();
 
 	@Override
-	public Byte wrap(AnnotationValue rawValue, AnnotationTarget target, SourceModelBuildingContext buildingContext) {
+	public Byte wrap(AnnotationValue rawValue, SourceModelBuildingContext buildingContext) {
 		assert rawValue != null;
 		return rawValue.asByte();
 	}

--- a/src/main/java/org/hibernate/models/internal/jandex/CharacterValueExtractor.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/CharacterValueExtractor.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
 import org.jboss.jandex.AnnotationValue;
@@ -22,11 +21,8 @@ public class CharacterValueExtractor extends AbstractValueExtractor<Character> {
 	public static final CharacterValueExtractor JANDEX_CHARACTER_EXTRACTOR = new CharacterValueExtractor();
 
 	@Override
-	protected Character extractAndWrap(
-			AnnotationValue jandexValue,
-			AnnotationTarget target,
-			SourceModelBuildingContext buildingContext) {
+	protected Character extractAndWrap(AnnotationValue jandexValue, SourceModelBuildingContext buildingContext) {
 		assert jandexValue != null;
-		return JANDEX_CHARACTER_VALUE_WRAPPER.wrap( jandexValue, target, buildingContext );
+		return JANDEX_CHARACTER_VALUE_WRAPPER.wrap( jandexValue, buildingContext );
 	}
 }

--- a/src/main/java/org/hibernate/models/internal/jandex/CharacterValueWrapper.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/CharacterValueWrapper.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.models.spi.ValueWrapper;
 
@@ -21,10 +20,7 @@ public class CharacterValueWrapper implements ValueWrapper<Character,AnnotationV
 	public static final CharacterValueWrapper JANDEX_CHARACTER_VALUE_WRAPPER = new CharacterValueWrapper();
 
 	@Override
-	public Character wrap(
-			AnnotationValue rawValue,
-			AnnotationTarget target,
-			SourceModelBuildingContext buildingContext) {
+	public Character wrap(AnnotationValue rawValue, SourceModelBuildingContext buildingContext) {
 		assert rawValue != null;
 		return rawValue.asChar();
 	}

--- a/src/main/java/org/hibernate/models/internal/jandex/ClassValueExtractor.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/ClassValueExtractor.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
@@ -19,11 +18,8 @@ public class ClassValueExtractor extends AbstractValueExtractor<ClassDetails> {
 	public static final ClassValueExtractor JANDEX_CLASS_EXTRACTOR = new ClassValueExtractor();
 
 	@Override
-	protected ClassDetails extractAndWrap(
-			AnnotationValue jandexValue,
-			AnnotationTarget target,
-			SourceModelBuildingContext buildingContext) {
+	protected ClassDetails extractAndWrap(AnnotationValue jandexValue, SourceModelBuildingContext buildingContext) {
 		assert jandexValue != null;
-		return ClassValueWrapper.JANDEX_CLASS_VALUE_WRAPPER.wrap( jandexValue, target, buildingContext );
+		return ClassValueWrapper.JANDEX_CLASS_VALUE_WRAPPER.wrap( jandexValue, buildingContext );
 	}
 }

--- a/src/main/java/org/hibernate/models/internal/jandex/ClassValueWrapper.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/ClassValueWrapper.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.models.spi.ValueWrapper;
@@ -23,7 +22,7 @@ public class ClassValueWrapper implements ValueWrapper<ClassDetails, AnnotationV
 	public static final ClassValueWrapper JANDEX_CLASS_VALUE_WRAPPER = new ClassValueWrapper();
 
 	@Override
-	public ClassDetails wrap(AnnotationValue rawValue, AnnotationTarget target, SourceModelBuildingContext buildingContext) {
+	public ClassDetails wrap(AnnotationValue rawValue, SourceModelBuildingContext buildingContext) {
 		final Type classReference = rawValue.asClass();
 		return buildingContext.getClassDetailsRegistry().resolveClassDetails( classReference.name().toString() );
 	}

--- a/src/main/java/org/hibernate/models/internal/jandex/DoubleValueExtractor.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/DoubleValueExtractor.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
 import org.jboss.jandex.AnnotationValue;
@@ -20,9 +19,8 @@ public class DoubleValueExtractor extends AbstractValueExtractor<Double> {
 	@Override
 	protected Double extractAndWrap(
 			AnnotationValue jandexValue,
-			AnnotationTarget target,
 			SourceModelBuildingContext buildingContext) {
 		assert jandexValue != null;
-		return DoubleValueWrapper.JANDEX_DOUBLE_VALUE_WRAPPER.wrap( jandexValue, target, buildingContext );
+		return DoubleValueWrapper.JANDEX_DOUBLE_VALUE_WRAPPER.wrap( jandexValue, buildingContext );
 	}
 }

--- a/src/main/java/org/hibernate/models/internal/jandex/DoubleValueWrapper.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/DoubleValueWrapper.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.models.spi.ValueWrapper;
 
@@ -21,10 +20,7 @@ public class DoubleValueWrapper implements ValueWrapper<Double,AnnotationValue> 
 	public static final DoubleValueWrapper JANDEX_DOUBLE_VALUE_WRAPPER = new DoubleValueWrapper();
 
 	@Override
-	public Double wrap(
-			AnnotationValue rawValue,
-			AnnotationTarget target,
-			SourceModelBuildingContext buildingContext) {
+	public Double wrap(AnnotationValue rawValue, SourceModelBuildingContext buildingContext) {
 		assert rawValue != null;
 		return rawValue.asDouble();
 	}

--- a/src/main/java/org/hibernate/models/internal/jandex/EnumValueExtractor.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/EnumValueExtractor.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
 import org.jboss.jandex.AnnotationValue;
@@ -26,11 +25,8 @@ public class EnumValueExtractor<E extends Enum<E>> extends AbstractValueExtracto
 	}
 
 	@Override
-	protected E extractAndWrap(
-			AnnotationValue jandexValue,
-			AnnotationTarget target,
-			SourceModelBuildingContext buildingContext) {
+	protected E extractAndWrap(AnnotationValue jandexValue, SourceModelBuildingContext buildingContext) {
 		assert jandexValue != null;
-		return wrapper.wrap( jandexValue, target, buildingContext );
+		return wrapper.wrap( jandexValue, buildingContext );
 	}
 }

--- a/src/main/java/org/hibernate/models/internal/jandex/EnumValueWrapper.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/EnumValueWrapper.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.models.spi.ValueWrapper;
 
@@ -25,7 +24,7 @@ public class EnumValueWrapper<E extends Enum<E>> implements ValueWrapper<E,Annot
 	}
 
 	@Override
-	public E wrap(AnnotationValue rawValue, AnnotationTarget target, SourceModelBuildingContext buildingContext) {
+	public E wrap(AnnotationValue rawValue, SourceModelBuildingContext buildingContext) {
 		assert rawValue != null;
 		final String enumName = rawValue.asEnum();
 		return Enum.valueOf( enumClass, enumName );

--- a/src/main/java/org/hibernate/models/internal/jandex/FloatValueExtractor.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/FloatValueExtractor.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
 import org.jboss.jandex.AnnotationValue;
@@ -18,11 +17,8 @@ public class FloatValueExtractor extends AbstractValueExtractor<Float> {
 	public static final FloatValueExtractor JANDEX_FLOAT_EXTRACTOR = new FloatValueExtractor();
 
 	@Override
-	protected Float extractAndWrap(
-			AnnotationValue jandexValue,
-			AnnotationTarget target,
-			SourceModelBuildingContext buildingContext) {
+	protected Float extractAndWrap(AnnotationValue jandexValue, SourceModelBuildingContext buildingContext) {
 		assert jandexValue != null;
-		return FloatValueWrapper.JANDEX_FLOAT_VALUE_WRAPPER.wrap( jandexValue, target, buildingContext );
+		return FloatValueWrapper.JANDEX_FLOAT_VALUE_WRAPPER.wrap( jandexValue, buildingContext );
 	}
 }

--- a/src/main/java/org/hibernate/models/internal/jandex/FloatValueWrapper.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/FloatValueWrapper.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.models.spi.ValueWrapper;
 
@@ -21,10 +20,7 @@ public class FloatValueWrapper implements ValueWrapper<Float,AnnotationValue> {
 	public static final FloatValueWrapper JANDEX_FLOAT_VALUE_WRAPPER = new FloatValueWrapper();
 
 	@Override
-	public Float wrap(
-			AnnotationValue rawValue,
-			AnnotationTarget target,
-			SourceModelBuildingContext buildingContext) {
+	public Float wrap(AnnotationValue rawValue, SourceModelBuildingContext buildingContext) {
 		assert rawValue != null;
 		return rawValue.asFloat();
 	}

--- a/src/main/java/org/hibernate/models/internal/jandex/IntegerValueExtractor.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/IntegerValueExtractor.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
 import org.jboss.jandex.AnnotationValue;
@@ -18,11 +17,8 @@ public class IntegerValueExtractor extends AbstractValueExtractor<Integer> {
 	public static final IntegerValueExtractor JANDEX_INTEGER_EXTRACTOR = new IntegerValueExtractor();
 
 	@Override
-	protected Integer extractAndWrap(
-			AnnotationValue jandexValue,
-			AnnotationTarget target,
-			SourceModelBuildingContext buildingContext) {
+	protected Integer extractAndWrap(AnnotationValue jandexValue, SourceModelBuildingContext buildingContext) {
 		assert jandexValue != null;
-		return IntegerValueWrapper.JANDEX_INTEGER_VALUE_WRAPPER.wrap( jandexValue, target, buildingContext );
+		return IntegerValueWrapper.JANDEX_INTEGER_VALUE_WRAPPER.wrap( jandexValue, buildingContext );
 	}
 }

--- a/src/main/java/org/hibernate/models/internal/jandex/IntegerValueWrapper.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/IntegerValueWrapper.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.models.spi.ValueWrapper;
 
@@ -21,10 +20,7 @@ public class IntegerValueWrapper implements ValueWrapper<Integer,AnnotationValue
 	public static final IntegerValueWrapper JANDEX_INTEGER_VALUE_WRAPPER = new IntegerValueWrapper();
 
 	@Override
-	public Integer wrap(
-			AnnotationValue rawValue,
-			AnnotationTarget target,
-			SourceModelBuildingContext buildingContext) {
+	public Integer wrap(AnnotationValue rawValue, SourceModelBuildingContext buildingContext) {
 		assert rawValue != null;
 		return rawValue.asInt();
 	}

--- a/src/main/java/org/hibernate/models/internal/jandex/JandexAnnotationUsage.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/JandexAnnotationUsage.java
@@ -11,7 +11,6 @@ import java.util.Map;
 
 import org.hibernate.models.internal.AnnotationProxy;
 import org.hibernate.models.spi.AnnotationDescriptor;
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.MutableAnnotationUsage;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
@@ -24,25 +23,21 @@ import org.jboss.jandex.AnnotationInstance;
  */
 public class JandexAnnotationUsage<A extends Annotation> implements MutableAnnotationUsage<A> {
 	private final AnnotationDescriptor<A> annotationDescriptor;
-	private final AnnotationTarget annotationTarget;
 
 	private final Map<String,?> attributeValueMap;
 
 	public JandexAnnotationUsage(
 			AnnotationInstance annotationInstance,
 			AnnotationDescriptor<A> annotationDescriptor,
-			AnnotationTarget annotationTarget,
 			SourceModelBuildingContext processingContext) {
 		assert annotationInstance != null : "Jandex AnnotationInstance was null";
 		assert annotationDescriptor != null : "AnnotationDescriptor was null - " + annotationInstance;
 
-		this.annotationTarget = annotationTarget;
 		this.annotationDescriptor = annotationDescriptor;
 
 		this.attributeValueMap = AnnotationUsageBuilder.extractAttributeValues(
 				annotationInstance,
 				annotationDescriptor,
-				annotationTarget,
 				processingContext
 		);
 	}
@@ -50,11 +45,6 @@ public class JandexAnnotationUsage<A extends Annotation> implements MutableAnnot
 	@Override
 	public AnnotationDescriptor<A> getAnnotationDescriptor() {
 		return annotationDescriptor;
-	}
-
-	@Override
-	public AnnotationTarget getAnnotationTarget() {
-		return annotationTarget;
 	}
 
 	@Override

--- a/src/main/java/org/hibernate/models/internal/jandex/LongValueExtractor.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/LongValueExtractor.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
 import org.jboss.jandex.AnnotationValue;
@@ -18,11 +17,8 @@ public class LongValueExtractor extends AbstractValueExtractor<Long> {
 	public static final LongValueExtractor JANDEX_LONG_EXTRACTOR = new LongValueExtractor();
 
 	@Override
-	protected Long extractAndWrap(
-			AnnotationValue jandexValue,
-			AnnotationTarget target,
-			SourceModelBuildingContext buildingContext) {
+	protected Long extractAndWrap(AnnotationValue jandexValue, SourceModelBuildingContext buildingContext) {
 		assert jandexValue != null;
-		return LongValueWrapper.JANDEX_LONG_VALUE_WRAPPER.wrap( jandexValue, target, buildingContext );
+		return LongValueWrapper.JANDEX_LONG_VALUE_WRAPPER.wrap( jandexValue, buildingContext );
 	}
 }

--- a/src/main/java/org/hibernate/models/internal/jandex/LongValueWrapper.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/LongValueWrapper.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.models.spi.ValueWrapper;
 
@@ -21,10 +20,7 @@ public class LongValueWrapper implements ValueWrapper<Long,AnnotationValue> {
 	public static final LongValueWrapper JANDEX_LONG_VALUE_WRAPPER = new LongValueWrapper();
 
 	@Override
-	public Long wrap(
-			AnnotationValue rawValue,
-			AnnotationTarget target,
-			SourceModelBuildingContext buildingContext) {
+	public Long wrap(AnnotationValue rawValue, SourceModelBuildingContext buildingContext) {
 		assert rawValue != null;
 		return rawValue.asLong();
 	}

--- a/src/main/java/org/hibernate/models/internal/jandex/NestedValueExtractor.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/NestedValueExtractor.java
@@ -9,7 +9,6 @@ package org.hibernate.models.internal.jandex;
 import java.lang.annotation.Annotation;
 
 import org.hibernate.models.spi.AnnotationDescriptor;
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.AnnotationUsage;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
@@ -32,8 +31,7 @@ public class NestedValueExtractor<A extends Annotation> extends AbstractValueExt
 	@Override
 	protected AnnotationUsage<A> extractAndWrap(
 			AnnotationValue jandexValue,
-			AnnotationTarget target,
 			SourceModelBuildingContext buildingContext) {
-		return wrapper.wrap( jandexValue, target, buildingContext );
+		return wrapper.wrap( jandexValue, buildingContext );
 	}
 }

--- a/src/main/java/org/hibernate/models/internal/jandex/NestedValueWrapper.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/NestedValueWrapper.java
@@ -9,7 +9,6 @@ package org.hibernate.models.internal.jandex;
 import java.lang.annotation.Annotation;
 
 import org.hibernate.models.spi.AnnotationDescriptor;
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.AnnotationUsage;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.models.spi.ValueWrapper;
@@ -31,11 +30,9 @@ public class NestedValueWrapper<A extends Annotation> implements ValueWrapper<An
 	}
 
 	@Override
-	public AnnotationUsage<A> wrap(
-			AnnotationValue rawValue,
-			AnnotationTarget target,
-			SourceModelBuildingContext buildingContext) {
+	public AnnotationUsage<A> wrap(AnnotationValue rawValue, SourceModelBuildingContext buildingContext) {
 		final AnnotationInstance nested = rawValue.asNested();
-		return AnnotationUsageBuilder.makeUsage( nested, descriptor, target, buildingContext );
+		assert nested.target() == null;
+		return AnnotationUsageBuilder.makeUsage( nested, descriptor, buildingContext );
 	}
 }

--- a/src/main/java/org/hibernate/models/internal/jandex/ShortValueExtractor.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/ShortValueExtractor.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
 import org.jboss.jandex.AnnotationValue;
@@ -17,12 +16,9 @@ import org.jboss.jandex.AnnotationValue;
 public class ShortValueExtractor extends AbstractValueExtractor<Short> {
 	public static final ShortValueExtractor JANDEX_SHORT_EXTRACTOR = new ShortValueExtractor();
 
-	protected Short extractAndWrap(
-			AnnotationValue jandexValue,
-			AnnotationTarget target,
-			SourceModelBuildingContext buildingContext) {
+	protected Short extractAndWrap(AnnotationValue jandexValue, SourceModelBuildingContext buildingContext) {
 		assert jandexValue != null;
-		return ShortValueWrapper.JANDEX_SHORT_VALUE_WRAPPER.wrap( jandexValue, target, buildingContext );
+		return ShortValueWrapper.JANDEX_SHORT_VALUE_WRAPPER.wrap( jandexValue, buildingContext );
 	}
 
 }

--- a/src/main/java/org/hibernate/models/internal/jandex/ShortValueWrapper.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/ShortValueWrapper.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.models.spi.ValueWrapper;
 
@@ -21,10 +20,7 @@ public class ShortValueWrapper implements ValueWrapper<Short,AnnotationValue> {
 	public static final ShortValueWrapper JANDEX_SHORT_VALUE_WRAPPER = new ShortValueWrapper();
 
 	@Override
-	public Short wrap(
-			AnnotationValue rawValue,
-			AnnotationTarget target,
-			SourceModelBuildingContext buildingContext) {
+	public Short wrap(AnnotationValue rawValue, SourceModelBuildingContext buildingContext) {
 		assert rawValue != null;
 		return rawValue.asShort();
 	}

--- a/src/main/java/org/hibernate/models/internal/jandex/StringValueExtractor.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/StringValueExtractor.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
 import org.jboss.jandex.AnnotationValue;
@@ -18,11 +17,8 @@ public class StringValueExtractor extends AbstractValueExtractor<String> {
 	public static final StringValueExtractor JANDEX_STRING_EXTRACTOR = new StringValueExtractor();
 
 	@Override
-	protected String extractAndWrap(
-			AnnotationValue jandexValue,
-			AnnotationTarget target,
-			SourceModelBuildingContext buildingContext) {
+	protected String extractAndWrap(AnnotationValue jandexValue, SourceModelBuildingContext buildingContext) {
 		assert jandexValue != null;
-		return StringValueWrapper.JANDEX_STRING_VALUE_WRAPPER.wrap( jandexValue, target, buildingContext );
+		return StringValueWrapper.JANDEX_STRING_VALUE_WRAPPER.wrap( jandexValue, buildingContext );
 	}
 }

--- a/src/main/java/org/hibernate/models/internal/jandex/StringValueWrapper.java
+++ b/src/main/java/org/hibernate/models/internal/jandex/StringValueWrapper.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jandex;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.models.spi.ValueWrapper;
 
@@ -21,10 +20,7 @@ public class StringValueWrapper implements ValueWrapper<String,AnnotationValue> 
 	public static final StringValueWrapper JANDEX_STRING_VALUE_WRAPPER = new StringValueWrapper();
 
 	@Override
-	public String wrap(
-			AnnotationValue rawValue,
-			AnnotationTarget target,
-			SourceModelBuildingContext buildingContext) {
+	public String wrap(AnnotationValue rawValue, SourceModelBuildingContext buildingContext) {
 		assert rawValue != null;
 		return rawValue.asString();
 	}

--- a/src/main/java/org/hibernate/models/internal/jdk/AbstractAnnotationTarget.java
+++ b/src/main/java/org/hibernate/models/internal/jdk/AbstractAnnotationTarget.java
@@ -51,7 +51,6 @@ public abstract class AbstractAnnotationTarget implements AnnotationTargetSuppor
 		final Map<Class<? extends Annotation>, AnnotationUsage<?>> result = new HashMap<>();
 		AnnotationUsageBuilder.processAnnotations(
 				annotationSupplier.get(),
-				this,
 				result::put,
 				buildingContext
 		);

--- a/src/main/java/org/hibernate/models/internal/jdk/AbstractValueExtractor.java
+++ b/src/main/java/org/hibernate/models/internal/jdk/AbstractValueExtractor.java
@@ -25,31 +25,28 @@ public abstract class AbstractValueExtractor<W,R> implements ValueExtractor<Anno
 	protected abstract W wrap(
 			R rawValue,
 			AttributeDescriptor<W> attributeDescriptor,
-			AnnotationTarget target,
 			SourceModelBuildingContext buildingContext);
 
 	@Override
 	public W extractValue(
 			Annotation annotation,
 			String attributeName,
-			AnnotationTarget target,
 			SourceModelBuildingContext buildingContext) {
 		final AnnotationDescriptor<? extends Annotation> annDescriptor = buildingContext
 				.getAnnotationDescriptorRegistry()
 				.getDescriptor( annotation.annotationType() );
-		return extractValue( annotation, annDescriptor.getAttribute( attributeName ), target, buildingContext );
+		return extractValue( annotation, annDescriptor.getAttribute( attributeName ), buildingContext );
 	}
 
 	@Override
 	public W extractValue(
 			Annotation annotation,
 			AttributeDescriptor<W> attributeDescriptor,
-			AnnotationTarget target,
 			SourceModelBuildingContext buildingContext) {
 		try {
 			//noinspection unchecked
 			final R rawValue = (R) attributeDescriptor.getAttributeMethod().invoke( annotation );
-			return wrap( rawValue, attributeDescriptor, target, buildingContext );
+			return wrap( rawValue, attributeDescriptor, buildingContext );
 		}
 		catch (IllegalAccessException | InvocationTargetException e) {
 			throw new AnnotationAccessException(

--- a/src/main/java/org/hibernate/models/internal/jdk/AnnotationUsageBuilder.java
+++ b/src/main/java/org/hibernate/models/internal/jdk/AnnotationUsageBuilder.java
@@ -19,7 +19,6 @@ import java.util.function.BiConsumer;
 import org.hibernate.models.internal.util.CollectionHelper;
 import org.hibernate.models.spi.AnnotationDescriptor;
 import org.hibernate.models.spi.AnnotationDescriptorRegistry;
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.AnnotationUsage;
 import org.hibernate.models.spi.AttributeDescriptor;
 import org.hibernate.models.spi.SourceModelBuildingContext;
@@ -36,7 +35,6 @@ public class AnnotationUsageBuilder {
 	 */
 	public static void processAnnotations(
 			Annotation[] annotations,
-			AnnotationTarget target,
 			BiConsumer<Class<? extends Annotation>, AnnotationUsage<?>> consumer,
 			SourceModelBuildingContext buildingContext) {
 		final AnnotationDescriptorRegistry annotationDescriptorRegistry = buildingContext.getAnnotationDescriptorRegistry();
@@ -59,7 +57,6 @@ public class AnnotationUsageBuilder {
 			final AnnotationUsage<?> usage = makeUsage(
 					annotation,
 					annotationDescriptor,
-					target,
 					buildingContext
 			);
 			consumer.accept( annotationType, usage );
@@ -69,10 +66,9 @@ public class AnnotationUsageBuilder {
 	public static <A extends Annotation> AnnotationUsage<A> makeUsage(
 			A annotation,
 			AnnotationDescriptor<A> annotationDescriptor,
-			AnnotationTarget target,
 			SourceModelBuildingContext buildingContext) {
 		//noinspection unchecked,rawtypes
-		return new JdkAnnotationUsage( annotation, annotationDescriptor, target, buildingContext );
+		return new JdkAnnotationUsage( annotation, annotationDescriptor, buildingContext );
 	}
 
 	/**
@@ -82,7 +78,6 @@ public class AnnotationUsageBuilder {
 	public static <A extends Annotation> Map<String,?> extractAttributeValues(
 			A annotation,
 			AnnotationDescriptor<A> annotationDescriptor,
-			AnnotationTarget target,
 			SourceModelBuildingContext buildingContext) {
 		if ( CollectionHelper.isEmpty( annotationDescriptor.getAttributes() ) ) {
 			return Collections.emptyMap();
@@ -94,7 +89,7 @@ public class AnnotationUsageBuilder {
 			final ValueExtractor valueExtractor = attributeDescriptor
 					.getTypeDescriptor()
 					.createJdkExtractor( buildingContext );
-			final Object value = valueExtractor.extractValue( annotation, attributeDescriptor, target, buildingContext );
+			final Object value = valueExtractor.extractValue( annotation, attributeDescriptor, buildingContext );
 			valueMap.put( attributeDescriptor.getName(), value );
 		}
 		return valueMap;

--- a/src/main/java/org/hibernate/models/internal/jdk/ArrayValueExtractor.java
+++ b/src/main/java/org/hibernate/models/internal/jdk/ArrayValueExtractor.java
@@ -27,8 +27,7 @@ public class ArrayValueExtractor<V,R> extends AbstractValueExtractor<List<V>,R[]
 	protected List<V> wrap(
 			R[] rawValues,
 			AttributeDescriptor<List<V>> attributeDescriptor,
-			AnnotationTarget target,
 			SourceModelBuildingContext buildingContext) {
-		return wrapper.wrap( rawValues, target, buildingContext );
+		return wrapper.wrap( rawValues, buildingContext );
 	}
 }

--- a/src/main/java/org/hibernate/models/internal/jdk/ArrayValueWrapper.java
+++ b/src/main/java/org/hibernate/models/internal/jdk/ArrayValueWrapper.java
@@ -11,7 +11,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.hibernate.models.internal.util.CollectionHelper;
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.models.spi.ValueWrapper;
 
@@ -26,18 +25,18 @@ public class ArrayValueWrapper<V,R> implements ValueWrapper<List<V>,R[]> {
 	}
 
 	@Override
-	public List<V> wrap(R[] rawValues, AnnotationTarget target, SourceModelBuildingContext buildingContext) {
+	public List<V> wrap(R[] rawValues, SourceModelBuildingContext buildingContext) {
 		if ( CollectionHelper.isEmpty( rawValues ) ) {
 			return Collections.emptyList();
 		}
 
 		if ( rawValues.length == 1 ) {
-			return Collections.singletonList( elementWrapper.wrap( rawValues[0], target, buildingContext ) );
+			return Collections.singletonList( elementWrapper.wrap( rawValues[0], buildingContext ) );
 		}
 
 		final List<V> result = new ArrayList<>( rawValues.length );
 		for ( int i = 0; i < rawValues.length; i++ ) {
-			result.add( elementWrapper.wrap( rawValues[i], target, buildingContext ) );
+			result.add( elementWrapper.wrap( rawValues[i], buildingContext ) );
 		}
 		return result;
 	}

--- a/src/main/java/org/hibernate/models/internal/jdk/ClassValueExtractor.java
+++ b/src/main/java/org/hibernate/models/internal/jdk/ClassValueExtractor.java
@@ -23,9 +23,8 @@ public class ClassValueExtractor extends AbstractValueExtractor<ClassDetails,Cla
 	protected ClassDetails wrap(
 			Class<?> rawValue,
 			AttributeDescriptor<ClassDetails> attributeDescriptor,
-			AnnotationTarget target,
 			SourceModelBuildingContext buildingContext) {
-		return JDK_CLASS_VALUE_WRAPPER.wrap( rawValue, target, buildingContext );
+		return JDK_CLASS_VALUE_WRAPPER.wrap( rawValue, buildingContext );
 	}
 
 }

--- a/src/main/java/org/hibernate/models/internal/jdk/ClassValueWrapper.java
+++ b/src/main/java/org/hibernate/models/internal/jdk/ClassValueWrapper.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jdk;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.models.spi.ValueWrapper;
@@ -18,7 +17,7 @@ public class ClassValueWrapper implements ValueWrapper<ClassDetails,Class<?>> {
 	public static final ClassValueWrapper JDK_CLASS_VALUE_WRAPPER = new ClassValueWrapper();
 
 	@Override
-	public ClassDetails wrap(Class<?> rawValue, AnnotationTarget target, SourceModelBuildingContext buildingContext) {
+	public ClassDetails wrap(Class<?> rawValue, SourceModelBuildingContext buildingContext) {
 		return buildingContext.getClassDetailsRegistry().resolveClassDetails( rawValue.getName() );
 	}
 }

--- a/src/main/java/org/hibernate/models/internal/jdk/JdkAnnotationUsage.java
+++ b/src/main/java/org/hibernate/models/internal/jdk/JdkAnnotationUsage.java
@@ -10,7 +10,6 @@ import java.lang.annotation.Annotation;
 import java.util.Map;
 
 import org.hibernate.models.spi.AnnotationDescriptor;
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.MutableAnnotationUsage;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 
@@ -20,30 +19,22 @@ import org.hibernate.models.spi.SourceModelBuildingContext;
 public class JdkAnnotationUsage<A extends Annotation> implements MutableAnnotationUsage<A> {
 	private final A annotation;
 	private final AnnotationDescriptor<A> annotationDescriptor;
-	private final AnnotationTarget location;
 
 	private final Map<String,?> valueMap;
 
 	public JdkAnnotationUsage(
 			A annotation,
 			AnnotationDescriptor<A> annotationDescriptor,
-			AnnotationTarget location,
 			SourceModelBuildingContext buildingContext) {
 		this.annotation = annotation;
 		this.annotationDescriptor = annotationDescriptor;
-		this.location = location;
 
-		this.valueMap = AnnotationUsageBuilder.extractAttributeValues( annotation, annotationDescriptor, location, buildingContext );
+		this.valueMap = AnnotationUsageBuilder.extractAttributeValues( annotation, annotationDescriptor, buildingContext );
 	}
 
 	@Override
 	public AnnotationDescriptor<A> getAnnotationDescriptor() {
 		return annotationDescriptor;
-	}
-
-	@Override
-	public AnnotationTarget getAnnotationTarget() {
-		return location;
 	}
 
 	@Override

--- a/src/main/java/org/hibernate/models/internal/jdk/NestedValueExtractor.java
+++ b/src/main/java/org/hibernate/models/internal/jdk/NestedValueExtractor.java
@@ -28,8 +28,7 @@ public class NestedValueExtractor<A extends Annotation> extends AbstractValueExt
 	protected AnnotationUsage<A> wrap(
 			A rawValue,
 			AttributeDescriptor<AnnotationUsage<A>> attributeDescriptor,
-			AnnotationTarget target,
 			SourceModelBuildingContext buildingContext) {
-		return wrapper.wrap( rawValue, target, buildingContext );
+		return wrapper.wrap( rawValue, buildingContext );
 	}
 }

--- a/src/main/java/org/hibernate/models/internal/jdk/NestedValueWrapper.java
+++ b/src/main/java/org/hibernate/models/internal/jdk/NestedValueWrapper.java
@@ -9,7 +9,6 @@ package org.hibernate.models.internal.jdk;
 import java.lang.annotation.Annotation;
 
 import org.hibernate.models.spi.AnnotationDescriptor;
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.AnnotationUsage;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.models.spi.ValueWrapper;
@@ -25,8 +24,7 @@ public class NestedValueWrapper<A extends Annotation> implements ValueWrapper<An
 	}
 
 	@Override
-	public AnnotationUsage<A> wrap(A rawValue, AnnotationTarget target, SourceModelBuildingContext buildingContext) {
-		return AnnotationUsageBuilder.makeUsage( rawValue, descriptor, target, buildingContext );
-
+	public AnnotationUsage<A> wrap(A rawValue, SourceModelBuildingContext buildingContext) {
+		return AnnotationUsageBuilder.makeUsage( rawValue, descriptor, buildingContext );
 	}
 }

--- a/src/main/java/org/hibernate/models/internal/jdk/PassThruExtractor.java
+++ b/src/main/java/org/hibernate/models/internal/jdk/PassThruExtractor.java
@@ -20,7 +20,6 @@ public class PassThruExtractor<V> extends AbstractValueExtractor<V,V> {
 	protected V wrap(
 			V rawValue,
 			AttributeDescriptor<V> attributeDescriptor,
-			AnnotationTarget target,
 			SourceModelBuildingContext buildingContext) {
 		return rawValue;
 	}

--- a/src/main/java/org/hibernate/models/internal/jdk/PassThruWrapper.java
+++ b/src/main/java/org/hibernate/models/internal/jdk/PassThruWrapper.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.models.internal.jdk;
 
-import org.hibernate.models.spi.AnnotationTarget;
 import org.hibernate.models.spi.SourceModelBuildingContext;
 import org.hibernate.models.spi.ValueWrapper;
 
@@ -20,7 +19,7 @@ public class PassThruWrapper<V> implements ValueWrapper<V,V> {
 	public static final PassThruWrapper PASS_THRU_WRAPPER = new PassThruWrapper();
 
 	@Override
-	public V wrap(V rawValue, AnnotationTarget target, SourceModelBuildingContext buildingContext) {
+	public V wrap(V rawValue, SourceModelBuildingContext buildingContext) {
 		return rawValue;
 	}
 }

--- a/src/main/java/org/hibernate/models/spi/AnnotationDescriptor.java
+++ b/src/main/java/org/hibernate/models/spi/AnnotationDescriptor.java
@@ -112,15 +112,7 @@ public interface AnnotationDescriptor<A extends Annotation> extends AnnotationTa
 			Consumer<MutableAnnotationUsage<A>> adjuster,
 			SourceModelBuildingContext context) {
 		// create the "empty" usage
-		final DynamicAnnotationUsage<A> usage = new DynamicAnnotationUsage<>( this, target, context );
-
-		// apply attribute defaults
-		getAttributes().forEach( (attr) -> {
-			final Object value = attr.getTypeDescriptor().createValue( attr, target, context );
-			if ( value != null ) {
-				usage.setAttributeValue( attr.getName(), value );
-			}
-		} );
+		final DynamicAnnotationUsage<A> usage = new DynamicAnnotationUsage<>( this, context );
 
 		// allow configuration
 		if ( adjuster != null ) {

--- a/src/main/java/org/hibernate/models/spi/AnnotationUsage.java
+++ b/src/main/java/org/hibernate/models/spi/AnnotationUsage.java
@@ -49,11 +49,6 @@ public interface AnnotationUsage<A extends Annotation> {
 	}
 
 	/**
-	 * The target where this usage occurs
-	 */
-	AnnotationTarget getAnnotationTarget();
-
-	/**
 	 * Create the Annotation representation of this usage
 	 */
 	A toAnnotation();

--- a/src/main/java/org/hibernate/models/spi/ValueExtractor.java
+++ b/src/main/java/org/hibernate/models/spi/ValueExtractor.java
@@ -32,7 +32,7 @@ public interface ValueExtractor<S, V> {
 	/**
 	 * Extract the value of the named attribute from the given annotation
 	 */
-	V extractValue(S annotation, String attributeName, AnnotationTarget target, SourceModelBuildingContext buildingContext);
+	V extractValue(S annotation, String attributeName, SourceModelBuildingContext buildingContext);
 
 	/**
 	 * Extract the value of the described attribute from the given annotation
@@ -40,8 +40,7 @@ public interface ValueExtractor<S, V> {
 	default V extractValue(
 			S annotation,
 			AttributeDescriptor<V> attributeDescriptor,
-			AnnotationTarget target,
 			SourceModelBuildingContext buildingContext) {
-		return extractValue( annotation, attributeDescriptor.getName(), target, buildingContext );
+		return extractValue( annotation, attributeDescriptor.getName(), buildingContext );
 	}
 }

--- a/src/main/java/org/hibernate/models/spi/ValueWrapper.java
+++ b/src/main/java/org/hibernate/models/spi/ValueWrapper.java
@@ -22,5 +22,5 @@ package org.hibernate.models.spi;
  * @author Steve Ebersole
  */
 public interface ValueWrapper<W,R> {
-	W wrap(R rawValue, AnnotationTarget target, SourceModelBuildingContext buildingContext);
+	W wrap(R rawValue, SourceModelBuildingContext buildingContext);
 }

--- a/src/test/java/org/hibernate/models/annotations/SimpleEntity.java
+++ b/src/test/java/org/hibernate/models/annotations/SimpleEntity.java
@@ -6,11 +6,19 @@
  */
 package org.hibernate.models.annotations;
 
+import java.util.List;
+
 import jakarta.persistence.Basic;
 import jakarta.persistence.Cacheable;
+import jakarta.persistence.CheckConstraint;
+import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.NamedNativeQueries;
+import jakarta.persistence.NamedNativeQuery;
 import jakarta.persistence.NamedQuery;
 import jakarta.persistence.SecondaryTable;
 import jakarta.persistence.Table;
@@ -19,12 +27,13 @@ import jakarta.persistence.Table;
  * @author Steve Ebersole
  */
 @Entity(name = "SimpleColumnEntity")
-@Table(name = "simple_entities")
+@Table(name = "simple_entities", check = @CheckConstraint ( constraint = "test" ))
 @SecondaryTable(name="another_table")
 @CustomAnnotation()
 @NamedQuery( name = "abc", query = "select me" )
 @NamedQuery( name = "xyz", query = "select you" )
 @Cacheable
+@NamedNativeQueries( @NamedNativeQuery( name = "native_1", query = "select * from simple_entities" ) )
 public class SimpleEntity {
 	@Id
 	@Column(name = "id", comment = "SimpleColumnEntity PK column")
@@ -37,6 +46,10 @@ public class SimpleEntity {
 	@Basic
 	@Column(table = "another_table", columnDefinition = "special_type")
 	private String name2;
+
+	@ElementCollection
+	@CollectionTable( joinColumns = @JoinColumn( name = "test" ) )
+	private List<String> elementCollection;
 
 	private SimpleEntity() {
 		// for use by Hibernate

--- a/src/test/java/org/hibernate/models/dynamic/DynamicAnnotationTests.java
+++ b/src/test/java/org/hibernate/models/dynamic/DynamicAnnotationTests.java
@@ -39,7 +39,6 @@ public class DynamicAnnotationTests {
 		final DynamicClassDetails dynamicEntity = new DynamicClassDetails( "DynamicEntity", buildingContext );
 		final DynamicAnnotationUsage<SequenceGenerator> generatorAnn = new DynamicAnnotationUsage<>(
 				JpaAnnotations.SEQUENCE_GENERATOR,
-				dynamicEntity,
 				buildingContext
 		);
 		assertThat( generatorAnn.getString( "name" ) ).isEqualTo( "" );
@@ -65,7 +64,6 @@ public class DynamicAnnotationTests {
 		final DynamicClassDetails dynamicEntity = new DynamicClassDetails( "DynamicEntity", buildingContext );
 		final DynamicAnnotationUsage<JoinTable> generatorAnn = new DynamicAnnotationUsage<>(
 				JpaAnnotations.JOIN_TABLE,
-				dynamicEntity,
 				buildingContext
 		);
 
@@ -88,7 +86,6 @@ public class DynamicAnnotationTests {
 		final DynamicClassDetails dynamicEntity = new DynamicClassDetails( "DynamicEntity", buildingContext );
 		final DynamicAnnotationUsage<JoinTable> generatorAnn = new DynamicAnnotationUsage<>(
 				JpaAnnotations.JOIN_TABLE,
-				dynamicEntity,
 				buildingContext
 		);
 
@@ -103,7 +100,6 @@ public class DynamicAnnotationTests {
 		final DynamicClassDetails dynamicEntity = new DynamicClassDetails( "DynamicEntity", buildingContext );
 		final DynamicAnnotationUsage<GeneratedValue> generatorAnn = new DynamicAnnotationUsage<>(
 				JpaAnnotations.GENERATED_VALUE,
-				dynamicEntity,
 				buildingContext
 		);
 
@@ -119,7 +115,6 @@ public class DynamicAnnotationTests {
 		final DynamicClassDetails dynamicEntity = new DynamicClassDetails( "DynamicEntity", buildingContext );
 		final DynamicAnnotationUsage<ElementCollection> elementCollectionAnn = new DynamicAnnotationUsage<>(
 				JpaAnnotations.ELEMENT_COLLECTION,
-				dynamicEntity,
 				buildingContext
 		);
 

--- a/src/test/java/org/hibernate/models/dynamic/ToAnnotationTest.java
+++ b/src/test/java/org/hibernate/models/dynamic/ToAnnotationTest.java
@@ -19,7 +19,6 @@ public class ToAnnotationTest {
 		final DynamicClassDetails dynamicEntity = new DynamicClassDetails( "DynamicEntity", buildingContext );
 		final DynamicAnnotationUsage<JoinTable> generatorAnn = new DynamicAnnotationUsage<>(
 				JpaAnnotations.JOIN_TABLE,
-				dynamicEntity,
 				buildingContext
 		);
 

--- a/src/test/java/org/hibernate/models/orm/JpaAnnotations.java
+++ b/src/test/java/org/hibernate/models/orm/JpaAnnotations.java
@@ -18,6 +18,7 @@ import jakarta.persistence.AttributeOverride;
 import jakarta.persistence.AttributeOverrides;
 import jakarta.persistence.Basic;
 import jakarta.persistence.Cacheable;
+import jakarta.persistence.CheckConstraint;
 import jakarta.persistence.CollectionTable;
 import jakarta.persistence.Column;
 import jakarta.persistence.ColumnResult;
@@ -185,6 +186,7 @@ public interface JpaAnnotations {
 	AnnotationDescriptor<SqlResultSetMapping> SQL_RESULT_SET_MAPPING = createOrmDescriptor( SqlResultSetMapping.class, SQL_RESULT_SET_MAPPINGS );
 	AnnotationDescriptor<StoredProcedureParameter> STORED_PROCEDURE_PARAMETER = createOrmDescriptor( StoredProcedureParameter.class );
 	AnnotationDescriptor<Table> TABLE = createOrmDescriptor( Table.class );
+	AnnotationDescriptor<CheckConstraint> CHECK_CONSTRAINT = createOrmDescriptor( CheckConstraint.class );
 	AnnotationDescriptor<TableGenerators> TABLE_GENERATORS = createOrmDescriptor( TableGenerators.class );
 	AnnotationDescriptor<TableGenerator> TABLE_GENERATOR = createOrmDescriptor( TableGenerator.class, TABLE_GENERATORS );
 	AnnotationDescriptor<Temporal> TEMPORAL = createOrmDescriptor( Temporal.class );


### PR DESCRIPTION
Addressed #63 by removing `AnnotationUsage#getAnnotationTarget`; also remove all unneeded references to `AnnotationTarget`s passed to the various implementations.