### PR TITLE
#68 - Remove lambda configuration argument from `AnnotationDescriptor#createUsage` and `DynamicClassDetails#applyAttribute`

### DIFF
--- a/src/main/java/org/hibernate/models/internal/dynamic/DynamicClassDetails.java
+++ b/src/main/java/org/hibernate/models/internal/dynamic/DynamicClassDetails.java
@@ -9,7 +9,6 @@ package org.hibernate.models.internal.dynamic;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Consumer;
 
 import org.hibernate.models.internal.ClassDetailsSupport;
 import org.hibernate.models.internal.ClassTypeDetailsImpl;
@@ -177,14 +176,12 @@ public class DynamicClassDetails extends AbstractAnnotationTarget implements Cla
 			ClassDetails type,
 			boolean isArray,
 			boolean isPlural,
-			Consumer<DynamicFieldDetails> configuration,
 			SourceModelBuildingContext context) {
 		return applyAttribute(
 				name,
 				new ClassTypeDetailsImpl( type, TypeDetails.Kind.CLASS ),
 				isArray,
 				isPlural,
-				configuration,
 				context
 		);
 	}
@@ -197,7 +194,6 @@ public class DynamicClassDetails extends AbstractAnnotationTarget implements Cla
 			TypeDetails type,
 			boolean isArray,
 			boolean isPlural,
-			Consumer<DynamicFieldDetails> configuration,
 			SourceModelBuildingContext context) {
 		final DynamicFieldDetails attribute = new DynamicFieldDetails(
 				name,
@@ -208,9 +204,6 @@ public class DynamicClassDetails extends AbstractAnnotationTarget implements Cla
 				isPlural,
 				context
 		);
-		if ( configuration != null ) {
-			configuration.accept( attribute );
-		}
 		addField( attribute );
 		return attribute;
 	}

--- a/src/main/java/org/hibernate/models/spi/AnnotationDescriptor.java
+++ b/src/main/java/org/hibernate/models/spi/AnnotationDescriptor.java
@@ -10,7 +10,6 @@ import java.lang.annotation.Annotation;
 import java.lang.annotation.Repeatable;
 import java.util.EnumSet;
 import java.util.List;
-import java.util.function.Consumer;
 
 import org.hibernate.models.IllegalCastException;
 import org.hibernate.models.UnknownAnnotationAttributeException;
@@ -96,27 +95,7 @@ public interface AnnotationDescriptor<A extends Annotation> extends AnnotationTa
 	 * @param context Access to needed services
 	 */
 	default MutableAnnotationUsage<A> createUsage(SourceModelBuildingContext context) {
-		return createUsage( null, context );
-	}
-
-	/**
-	 * Create a usage of this annotation with all attribute values defaulted, allowing customization prior to return.
-	 *
-	 * @param adjuster Callback to allow adjusting the created usage prior to return.
-	 * @param context Access to needed services
-	 */
-	default MutableAnnotationUsage<A> createUsage(
-			Consumer<MutableAnnotationUsage<A>> adjuster,
-			SourceModelBuildingContext context) {
-		// create the "empty" usage
-		final DynamicAnnotationUsage<A> usage = new DynamicAnnotationUsage<>( this, context );
-
-		// allow configuration
-		if ( adjuster != null ) {
-			adjuster.accept( usage );
-		}
-
-		return usage;
+		return new DynamicAnnotationUsage<>( this, context );
 	}
 
 	@Override

--- a/src/main/java/org/hibernate/models/spi/MutableAnnotationTarget.java
+++ b/src/main/java/org/hibernate/models/spi/MutableAnnotationTarget.java
@@ -7,7 +7,6 @@
 package org.hibernate.models.spi;
 
 import java.lang.annotation.Annotation;
-import java.util.function.Consumer;
 
 /**
  * Extension of AnnotationTarget which allows manipulation of the annotations
@@ -33,27 +32,12 @@ public interface MutableAnnotationTarget extends AnnotationTarget {
 	default <A extends Annotation> MutableAnnotationUsage<A> applyAnnotationUsage(
 			AnnotationDescriptor<A> annotationType,
 			SourceModelBuildingContext buildingContext) {
-		return applyAnnotationUsage( annotationType, null, buildingContext );
-	}
-
-	/**
-	 * Applies a usage of the given {@code annotationType} to this target, allowing
-	 * for configuration of the applied usage.  Will return an existing usage, if one,
-	 * or create a new usage.
-	 */
-	default <A extends Annotation> MutableAnnotationUsage<A> applyAnnotationUsage(
-			AnnotationDescriptor<A> annotationType,
-			Consumer<MutableAnnotationUsage<A>> configuration,
-			SourceModelBuildingContext buildingContext) {
 		final MutableAnnotationUsage<A> existing = (MutableAnnotationUsage<A>) getAnnotationUsage( annotationType );
 		if ( existing != null ) {
-			if ( configuration != null ) {
-				configuration.accept( existing );
-			}
 			return existing;
 		}
 
-		final MutableAnnotationUsage<A> usage = annotationType.createUsage( configuration, buildingContext );
+		final MutableAnnotationUsage<A> usage = annotationType.createUsage( buildingContext );
 		addAnnotationUsage( usage );
 		return usage;
 	}

--- a/src/test/java/org/hibernate/models/annotations/AnnotationUsageTests.java
+++ b/src/test/java/org/hibernate/models/annotations/AnnotationUsageTests.java
@@ -158,7 +158,7 @@ public class AnnotationUsageTests {
 	@Test
 	void testDynamicAttributeCreation() {
 		final SourceModelBuildingContextImpl buildingContext = createBuildingContext( (Index) null, SimpleEntity.class );
-		final AnnotationUsage<Column> usage = JpaAnnotations.COLUMN.createUsage( null, buildingContext );
+		final AnnotationUsage<Column> usage = JpaAnnotations.COLUMN.createUsage( buildingContext );
 		// check the attribute defaults
 		assertThat( usage.getString( "name" ) ).isEqualTo( "" );
 		assertThat( usage.getString( "table" ) ).isEqualTo( "" );

--- a/src/test/java/org/hibernate/models/annotations/DefaultValueTests.java
+++ b/src/test/java/org/hibernate/models/annotations/DefaultValueTests.java
@@ -69,7 +69,7 @@ public class DefaultValueTests {
 		assertThat( annotationUsage.getClassDetails( "someClassValue" ).toJavaClass() ).isEqualTo( Entity.class );
 
 		// apparently the models code does not use this method directly, but ORM does.  This is the one that was leading to NPE
-		final MutableAnnotationUsage<CustomAnnotation> created = descriptor.createUsage( null, buildingContext );
+		final MutableAnnotationUsage<CustomAnnotation> created = descriptor.createUsage( buildingContext );
 		assertThat( created.getClassDetails( "someClassValue" ) ).isNull();
 	}
 

--- a/src/test/java/org/hibernate/models/dynamic/SimpleDynamicModelTests.java
+++ b/src/test/java/org/hibernate/models/dynamic/SimpleDynamicModelTests.java
@@ -60,31 +60,28 @@ public class SimpleDynamicModelTests {
 		);
 		assertThat( created ).isSameAs( preExisting );
 
-		entityDetails.applyAttribute(
+		final DynamicFieldDetails idMember = entityDetails.applyAttribute(
 				"id",
 				integerTypeDetails,
 				false,
 				false,
-				fieldDetails -> {
-					final MutableAnnotationUsage<Id> first = fieldDetails.applyAnnotationUsage(
-							JpaAnnotations.ID,
-							buildingContext
-					);
-					final MutableAnnotationUsage<Id> second = fieldDetails.applyAnnotationUsage(
-							JpaAnnotations.ID,
-							buildingContext
-					);
-					assertThat( first ).isSameAs( second );
-				},
 				buildingContext
 		);
+		final MutableAnnotationUsage<Id> first = idMember.applyAnnotationUsage(
+				JpaAnnotations.ID,
+				buildingContext
+		);
+		final MutableAnnotationUsage<Id> second = idMember.applyAnnotationUsage(
+				JpaAnnotations.ID,
+				buildingContext
+		);
+		assertThat( first ).isSameAs( second );
 
 		entityDetails.applyAttribute(
 				"name",
 				stringTypeDetails,
 				false,
 				false,
-				null,
 				buildingContext
 		);
 
@@ -137,7 +134,6 @@ public class SimpleDynamicModelTests {
 				stringClassDetails,
 				false,
 				false,
-				null,
 				buildingContext
 		);
 
@@ -146,7 +142,6 @@ public class SimpleDynamicModelTests {
 				stringClassDetails,
 				false,
 				false,
-				null,
 				buildingContext
 		);
 
@@ -169,24 +164,20 @@ public class SimpleDynamicModelTests {
 				integerTypeDetails,
 				false,
 				false,
-				(fieldDetails) -> {
-					final MutableAnnotationUsage<Id> idUsage = fieldDetails.applyAnnotationUsage( JpaAnnotations.ID, buildingContext );
-					assertThat( idUsage ).isNotNull();
-				},
 				buildingContext
 		);
+		final MutableAnnotationUsage<Id> idUsage = idMember.applyAnnotationUsage( JpaAnnotations.ID, buildingContext );
+		assertThat( idUsage ).isNotNull();
 
 		final DynamicFieldDetails nameMember = entityDetails.applyAttribute(
 				"name",
 				new ClassTypeDetailsImpl( nameEmbeddableDetails, TypeDetails.Kind.CLASS ),
 				false,
 				false,
-				(fieldDetails) -> {
-					final MutableAnnotationUsage<Embedded> embeddedUsage = fieldDetails.applyAnnotationUsage( JpaAnnotations.EMBEDDED, buildingContext );
-					assertThat( embeddedUsage ).isNotNull();
-				},
 				buildingContext
 		);
+		final MutableAnnotationUsage<Embedded> embeddedUsage = nameMember.applyAnnotationUsage( JpaAnnotations.EMBEDDED, buildingContext );
+		assertThat( embeddedUsage ).isNotNull();
 
 
 		// ASSERTIONS


### PR DESCRIPTION
Addresses https://github.com/hibernate/hibernate-models/issues/68.