### PR TITLE
#92 Add archive task configuration to make the build reproducible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,13 @@ dependencies {
 // Java handling
 // ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+// To force the build produce the same byte-for-byte archives and hence make Hibernate Models build reproducible.
+// See also https://docs.gradle.org/current/userguide/working_with_files.html#sec:reproducible_archives
+tasks.withType(AbstractArchiveTask).configureEach {
+	preserveFileTimestamps = false
+	reproducibleFileOrder = true
+}
+
 java {
 	sourceCompatibility = jdks.versions.baseline.get() as int
 	targetCompatibility = jdks.versions.baseline.get() as int


### PR DESCRIPTION
Fixes https://github.com/hibernate/hibernate-models/issues/92

here's how I've tested locally:

```
# build with no cache:
./gradlew --no-daemon --no-build-cache clean assemble publishToMavenLocal -Pskip.signing

# calculate md5s:
md5sum build/libs/hibernate-models-1.0.0-SNAPSHOT.jar build/libs/hibernate-models-1.0.0-SNAPSHOT-javadoc.jar build/libs/hibernate-models-1.0.0-SNAPSHOT-sources.jar

# rebuild with no cache again:
./gradlew --no-daemon --no-build-cache clean assemble publishToMavenLocal -Pskip.signing

# calculate md5s again and compare with the previous results:
md5sum build/libs/hibernate-models-1.0.0-SNAPSHOT.jar build/libs/hibernate-models-1.0.0-SNAPSHOT-javadoc.jar build/libs/hibernate-models-1.0.0-SNAPSHOT-sources.jar