### PR TITLE
Add maven-central publishing placeholder

### DIFF
--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -52,8 +52,14 @@ pipeline {
                                         configFile(fileId: 'release.config.ssh.knownhosts', targetLocation: env.HOME + '/.ssh/known_hosts')]) {
                         // using MAVEN_GPG_PASSPHRASE (the default env variable name for passphrase in maven gpg plugin)
                         withCredentials([file(credentialsId: 'release.gpg.private-key', variable: 'RELEASE_GPG_PRIVATE_KEY_PATH'),
-                                         string(credentialsId: 'release.gpg.passphrase', variable: 'JRELEASER_GPG_PASSPHRASE'),
+                                         // TODO: Once we switch to maven-central publishing (from nexus2) we need to add a new credentials
+                                         //  to use the following env variable names to set the user/password:
+                                         //  - JRELEASER_MAVENCENTRAL_USERNAME
+                                         //  - JRELEASER_MAVENCENTRAL_TOKEN
+                                         //  Also use the new `credentialsId` for Maven Central, e.g.:
+                                         //  usernamePassword(credentialsId: '???????', passwordVariable: 'JRELEASER_MAVENCENTRAL_TOKEN', usernameVariable: 'JRELEASER_MAVENCENTRAL_USERNAME'),
                                          usernamePassword(credentialsId: 'ossrh.sonatype.org', passwordVariable: 'JRELEASER_NEXUS2_PASSWORD', usernameVariable: 'JRELEASER_NEXUS2_USERNAME'),
+                                         string(credentialsId: 'release.gpg.passphrase', variable: 'JRELEASER_GPG_PASSPHRASE'),
                                          string(credentialsId: 'Hibernate-CI.github.com', variable: 'JRELEASER_GITHUB_TOKEN')]) {
                             sshagent(['ed25519.Hibernate-CI.github.com']) {
                                 sh 'cat $HOME/.ssh/config'

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -12,7 +12,7 @@ release:
 # File signing is always active
 signing:
   mode: COMMAND
-  active: ALWAYS
+  active: RELEASE
   armored: true
 
 # Deploy JARs and POMs to Maven Central
@@ -20,10 +20,20 @@ deploy:
   maven:
     nexus2:
       maven-central:
-        active: ALWAYS
+        active: RELEASE
         url: https://oss.sonatype.org/service/local
         snapshotUrl: https://oss.sonatype.org/content/repositories/snapshots/
         closeRepository: true
-        releaseRepository: true
         stagingRepositories:
           - build/staging-deploy/maven
+    mavenCentral:
+      maven-central:
+        # TODO: Change to RELEASE once switching to Maven-Central:
+        active: NEVER
+        url: https://central.sonatype.com/api/v1/publisher
+        snapshotSupported: false
+        applyMavenCentralRules: true
+        stagingRepositories:
+          - build/staging-deploy/maven
+        # Deployment identifier used for publication.
+        # deploymentId: dd9991b0-18a7-41e7-b1fe-37b8ea936f85


### PR DESCRIPTION
The thing is that the current config works fine for the OSSRH publishing. Once we switch to the maven-central publishing API we'd need that second config (`mavenCentral`). So the idea @dreab8 and I had was to include the "placeholder" configs in the repositories with `mavenCentral` set to `active: NEVER` and then once we switch, it'll be easier for whoever works on the change to apply it.