### PR TITLE
Add the name of the staging repository

### DIFF
--- a/buildSrc/src/main/groovy/publishing-config.gradle
+++ b/buildSrc/src/main/groovy/publishing-config.gradle
@@ -51,6 +51,7 @@ publishing {
 	}
 	repositories {
 		maven {
+			name = 'staging'
 			url = rootProject.layout.buildDirectory.dir("staging-deploy${File.separator}maven")
 		}
 	}


### PR DESCRIPTION
so that we can reference it in the publish task explicitly