### PR TITLE
#133 Move constant class `TypeDetails` from interface to dedicated class

### DIFF
--- a/hibernate-models/src/main/java/org/hibernate/models/internal/CollectionElementSwitch.java
+++ b/hibernate-models/src/main/java/org/hibernate/models/internal/CollectionElementSwitch.java
@@ -6,7 +6,6 @@ package org.hibernate.models.internal;
 
 import java.util.Collection;
 
-import org.hibernate.models.spi.ClassBasedTypeDetails;
 import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.ClassTypeDetails;
 import org.hibernate.models.spi.ParameterizedTypeDetails;
@@ -14,6 +13,8 @@ import org.hibernate.models.spi.TypeDetails;
 import org.hibernate.models.spi.TypeVariableDetails;
 import org.hibernate.models.spi.TypeVariableReferenceDetails;
 import org.hibernate.models.spi.WildcardTypeDetails;
+
+import static org.hibernate.models.spi.StandardTypeDetails.OBJECT_TYPE_DETAILS;
 
 /**
  * Used to determine the type details for a Collection element - see {@linkplain #extractCollectionElementType(TypeDetails)}
@@ -45,7 +46,7 @@ public class CollectionElementSwitch extends TypeDetailsSwitchSupport<TypeDetail
 		}
 
 		// otherwise, assume Object
-		return ClassBasedTypeDetails.OBJECT_TYPE_DETAILS;
+		return OBJECT_TYPE_DETAILS;
 	}
 
 	private final TypeDetails memberTypeDetails;

--- a/hibernate-models/src/main/java/org/hibernate/models/internal/MapKeySwitch.java
+++ b/hibernate-models/src/main/java/org/hibernate/models/internal/MapKeySwitch.java
@@ -6,7 +6,6 @@ package org.hibernate.models.internal;
 
 import java.util.Map;
 
-import org.hibernate.models.spi.ClassBasedTypeDetails;
 import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.ClassTypeDetails;
 import org.hibernate.models.spi.ParameterizedTypeDetails;
@@ -14,6 +13,8 @@ import org.hibernate.models.spi.TypeDetails;
 import org.hibernate.models.spi.TypeVariableDetails;
 import org.hibernate.models.spi.TypeVariableReferenceDetails;
 import org.hibernate.models.spi.WildcardTypeDetails;
+
+import static org.hibernate.models.spi.StandardTypeDetails.OBJECT_TYPE_DETAILS;
 
 /**
  * Used to determine the type details for a Map key - see {@linkplain #extractMapKeyType(TypeDetails)}
@@ -45,7 +46,7 @@ public class MapKeySwitch extends TypeDetailsSwitchSupport<TypeDetails> {
 		}
 
 		// otherwise, assume Object
-		return ClassBasedTypeDetails.OBJECT_TYPE_DETAILS;
+		return OBJECT_TYPE_DETAILS;
 	}
 
 	private final TypeDetails memberTypeDetails;

--- a/hibernate-models/src/main/java/org/hibernate/models/internal/MapValueSwitch.java
+++ b/hibernate-models/src/main/java/org/hibernate/models/internal/MapValueSwitch.java
@@ -6,7 +6,6 @@ package org.hibernate.models.internal;
 
 import java.util.Map;
 
-import org.hibernate.models.spi.ClassBasedTypeDetails;
 import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.ClassTypeDetails;
 import org.hibernate.models.spi.ParameterizedTypeDetails;
@@ -14,6 +13,8 @@ import org.hibernate.models.spi.TypeDetails;
 import org.hibernate.models.spi.TypeVariableDetails;
 import org.hibernate.models.spi.TypeVariableReferenceDetails;
 import org.hibernate.models.spi.WildcardTypeDetails;
+
+import static org.hibernate.models.spi.StandardTypeDetails.OBJECT_TYPE_DETAILS;
 
 /**
  * Used to determine the type details for a Map value - see {@linkplain #extractMapValueType(TypeDetails)}
@@ -45,7 +46,7 @@ public class MapValueSwitch extends TypeDetailsSwitchSupport<TypeDetails> {
 		}
 
 		// otherwise, assume Object
-		return ClassBasedTypeDetails.OBJECT_TYPE_DETAILS;
+		return OBJECT_TYPE_DETAILS;
 	}
 
 	private final TypeDetails memberTypeDetails;

--- a/hibernate-models/src/main/java/org/hibernate/models/internal/WildcardTypeDetailsImpl.java
+++ b/hibernate-models/src/main/java/org/hibernate/models/internal/WildcardTypeDetailsImpl.java
@@ -4,10 +4,11 @@
  */
 package org.hibernate.models.internal;
 
-import org.hibernate.models.spi.ClassTypeDetails;
 import org.hibernate.models.spi.TypeDetails;
 import org.hibernate.models.spi.TypeVariableDetails;
 import org.hibernate.models.spi.WildcardTypeDetails;
+
+import static org.hibernate.models.spi.StandardTypeDetails.OBJECT_TYPE_DETAILS;
 
 /**
  * @author Steve Ebersole
@@ -42,7 +43,7 @@ public record WildcardTypeDetailsImpl(TypeDetails bound, boolean isExtends) impl
 	 * @return the upper bound, or {@code Object} if this wildcard has a lower bound
 	 */
 	@Override public TypeDetails getExtendsBound() {
-		return isExtends ? bound : ClassTypeDetails.OBJECT_TYPE_DETAILS;
+		return isExtends ? bound : OBJECT_TYPE_DETAILS;
 	}
 
 	/**

--- a/hibernate-models/src/main/java/org/hibernate/models/internal/jdk/JdkTrackingTypeSwitch.java
+++ b/hibernate-models/src/main/java/org/hibernate/models/internal/jdk/JdkTrackingTypeSwitch.java
@@ -35,6 +35,7 @@ import org.hibernate.models.spi.WildcardTypeDetails;
 
 import static org.hibernate.models.internal.jdk.JdkBuilders.isVoid;
 import static org.hibernate.models.internal.util.CollectionHelper.arrayList;
+import static org.hibernate.models.spi.StandardTypeDetails.OBJECT_TYPE_DETAILS;
 
 /**
  * @author Steve Ebersole
@@ -83,14 +84,14 @@ public class JdkTrackingTypeSwitch implements JdkTypeSwitch<TypeDetails> {
 			final int numberOfBounds = CollectionHelper.length( wildcardType.getUpperBounds() );
 			final TypeDetails upper = numberOfBounds == 1
 					? switcher.switchType( wildcardType.getUpperBounds()[0] )
-					: ClassBasedTypeDetails.OBJECT_TYPE_DETAILS;
+					: OBJECT_TYPE_DETAILS;
 			return new WildcardTypeDetailsImpl( upper, true );
 		}
 
 		final int numberOfBounds = CollectionHelper.length( lowerBounds );
 		final TypeDetails lower = numberOfBounds == 1
 				? switcher.switchType( lowerBounds[0] )
-				: ClassBasedTypeDetails.OBJECT_TYPE_DETAILS;
+				: OBJECT_TYPE_DETAILS;
 		return new WildcardTypeDetailsImpl( lower, false );
 	}
 

--- a/hibernate-models/src/main/java/org/hibernate/models/spi/ClassBasedTypeDetails.java
+++ b/hibernate-models/src/main/java/org/hibernate/models/spi/ClassBasedTypeDetails.java
@@ -4,34 +4,12 @@
  */
 package org.hibernate.models.spi;
 
-import org.hibernate.models.internal.ClassTypeDetailsImpl;
-
 /**
  * Types which are expressible as a {@linkplain #getClassDetails class}
  *
  * @author Steve Ebersole
  */
 public interface ClassBasedTypeDetails extends TypeDetails {
-	/**
-	 * Type details for Object
-	 */
-	ClassTypeDetails OBJECT_TYPE_DETAILS = new ClassTypeDetailsImpl( ClassDetails.OBJECT_CLASS_DETAILS, Kind.CLASS );
-
-	/**
-	 * Details for {@code Class.class}
-	 */
-	TypeDetails CLASS_TYPE_DETAILS = new ClassTypeDetailsImpl( ClassDetails.CLASS_CLASS_DETAILS, Kind.CLASS );
-
-	/**
-	 * Details for {@code void.class}
-	 */
-	TypeDetails VOID_TYPE_DETAILS = new ClassTypeDetailsImpl( ClassDetails.VOID_CLASS_DETAILS, Kind.VOID );
-
-	/**
-	 * Details for {@code Void.class}
-	 */
-	TypeDetails VOID_OBJECT_TYPE_DETAILS = new ClassTypeDetailsImpl( ClassDetails.VOID_CLASS_DETAILS, Kind.VOID );
-
 	ClassDetails getClassDetails();
 
 	@Override

--- a/hibernate-models/src/main/java/org/hibernate/models/spi/StandardTypeDetails.java
+++ b/hibernate-models/src/main/java/org/hibernate/models/spi/StandardTypeDetails.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.models.spi;
+
+import org.hibernate.models.internal.ClassTypeDetailsImpl;
+import org.hibernate.models.internal.WildcardTypeDetailsImpl;
+
+/**
+ * Container for constant static {@link TypeDetails} references used often.
+ */
+public final class StandardTypeDetails {
+	/**
+	 * Type details for Object
+	 */
+	public static final ClassTypeDetails OBJECT_TYPE_DETAILS = new ClassTypeDetailsImpl(
+			ClassDetails.OBJECT_CLASS_DETAILS,
+			TypeDetails.Kind.CLASS
+	);
+
+	/**
+	 * Details for {@code Class.class}
+	 */
+	public static final TypeDetails CLASS_TYPE_DETAILS = new ClassTypeDetailsImpl(
+			ClassDetails.CLASS_CLASS_DETAILS,
+			TypeDetails.Kind.CLASS
+	);
+
+	/**
+	 * Details for {@code void.class}
+	 */
+	public static final TypeDetails VOID_TYPE_DETAILS = new ClassTypeDetailsImpl(
+			ClassDetails.VOID_CLASS_DETAILS,
+			TypeDetails.Kind.VOID
+	);
+
+	/**
+	 * Details for {@code Void.class}
+	 */
+	public static final TypeDetails VOID_OBJECT_TYPE_DETAILS = new ClassTypeDetailsImpl(
+			ClassDetails.VOID_CLASS_DETAILS,
+			TypeDetails.Kind.VOID
+	);
+
+	/**
+	 * A wildcard without a bound.  In other words, {@code ?}.
+	 */
+	WildcardTypeDetails UNBOUNDED = new WildcardTypeDetailsImpl( null, true );
+
+	// restrict instantiation
+	private StandardTypeDetails() {
+	}
+}

--- a/hibernate-models/src/main/java/org/hibernate/models/spi/TypeDetailsHelper.java
+++ b/hibernate-models/src/main/java/org/hibernate/models/spi/TypeDetailsHelper.java
@@ -13,7 +13,7 @@ import org.hibernate.models.internal.PrimitiveKind;
 import org.hibernate.models.internal.util.CollectionHelper;
 
 import static org.hibernate.models.internal.util.CollectionHelper.arrayList;
-import static org.hibernate.models.spi.ClassBasedTypeDetails.OBJECT_TYPE_DETAILS;
+import static org.hibernate.models.spi.StandardTypeDetails.OBJECT_TYPE_DETAILS;
 
 /**
  * Helper utilities for dealing with {@linkplain TypeDetails}

--- a/hibernate-models/src/main/java/org/hibernate/models/spi/WildcardTypeDetails.java
+++ b/hibernate-models/src/main/java/org/hibernate/models/spi/WildcardTypeDetails.java
@@ -4,8 +4,6 @@
  */
 package org.hibernate.models.spi;
 
-import org.hibernate.models.internal.WildcardTypeDetailsImpl;
-
 /**
  * Models a wildcard type declaration.
  *
@@ -14,11 +12,6 @@ import org.hibernate.models.internal.WildcardTypeDetailsImpl;
  * @author Steve Ebersole
  */
 public interface WildcardTypeDetails extends TypeDetails {
-	/**
-	 * A wildcard without a bound.  In other words, {@code ?}.
-	 */
-	WildcardTypeDetails UNBOUNDED = new WildcardTypeDetailsImpl( null, true );
-
 	TypeDetails getBound();
 
 	boolean isExtends();

--- a/hibernate-models/src/test/java/org/hibernate/models/testing/tests/classes/GenericsTests.java
+++ b/hibernate-models/src/test/java/org/hibernate/models/testing/tests/classes/GenericsTests.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.models.testing.tests.classes;
 
-import org.hibernate.models.spi.ClassBasedTypeDetails;
 import org.hibernate.models.spi.ClassDetails;
 import org.hibernate.models.spi.ClassDetailsRegistry;
 import org.hibernate.models.spi.ModelsContext;
@@ -17,6 +16,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.models.spi.StandardTypeDetails.OBJECT_TYPE_DETAILS;
 import static org.hibernate.models.testing.TestHelper.buildModelContext;
 
 /**
@@ -44,7 +44,7 @@ public class GenericsTests {
 		assertThat( wrappedType.getTypeKind() ).isEqualTo( TypeDetails.Kind.TYPE_VARIABLE );
 		assertThat( wrappedType.asTypeVariable().getIdentifier() ).isEqualTo( "T" );
 		assertThat( wrappedType.asTypeVariable().getBounds() ).hasSize( 1 );
-		assertThat( wrappedType.asTypeVariable().getBounds() ).contains( ClassBasedTypeDetails.OBJECT_TYPE_DETAILS );
+		assertThat( wrappedType.asTypeVariable().getBounds() ).contains( OBJECT_TYPE_DETAILS );
 		assertThat( wrappedType.isResolved() ).isFalse();
 		assertThat( wrappedType.determineRawClass().isResolved() ).isTrue();
 

--- a/hibernate-models/src/test/java/org/hibernate/models/testing/tests/generics/BaselineTests.java
+++ b/hibernate-models/src/test/java/org/hibernate/models/testing/tests/generics/BaselineTests.java
@@ -13,6 +13,7 @@ import org.hibernate.models.spi.TypeDetails;
 import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.models.spi.StandardTypeDetails.OBJECT_TYPE_DETAILS;
 import static org.hibernate.models.testing.TestHelper.createModelContext;
 
 /**
@@ -21,7 +22,7 @@ import static org.hibernate.models.testing.TestHelper.createModelContext;
 public class BaselineTests {
 	@Test
 	void testObjectUse() {
-		assertThat( ClassTypeDetails.OBJECT_TYPE_DETAILS.asClassType().getClassDetails() ).isSameAs( ClassDetails.OBJECT_CLASS_DETAILS );
+		assertThat( OBJECT_TYPE_DETAILS.asClassType().getClassDetails() ).isSameAs( ClassDetails.OBJECT_CLASS_DETAILS );
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #133.

Moving static constant `ClassTypeDetailsImpl` references to a dedicated class to avoid deadlocks waiting on `<clinit>` of the `ClassBasedTypeDetails` interface.