### PR TITLE
Add module info for main artifacts

### DIFF
--- a/buildSrc/src/main/groovy/published-java-module.gradle
+++ b/buildSrc/src/main/groovy/published-java-module.gradle
@@ -16,15 +16,7 @@ java {
 	withSourcesJar()
 }
 
-def moduleNameBase = project.name.startsWith( 'hibernate-' ) ? name.drop( 'hibernate-'.length() ): name
-def moduleName = "org.hibernate.$moduleNameBase".replace('-','.')
-
 tasks.named("jar") {
-	manifest {
-		attributes(
-				'Automatic-Module-Name': moduleName
-		)
-	}
 	metaInf {
 		from(rootProject.projectDir, {
 			include "LICENSE"

--- a/hibernate-models-bytebuddy/src/main/java/module-info.java
+++ b/hibernate-models-bytebuddy/src/main/java/module-info.java
@@ -1,0 +1,15 @@
+module org.hibernate.models.bytebuddy {
+	requires org.jboss.logging;
+	requires net.bytebuddy;
+
+	requires transitive org.hibernate.models;
+
+	exports org.hibernate.models.bytebuddy;
+	exports org.hibernate.models.bytebuddy.spi;
+	// exports org.hibernate.models.bytebuddy.internal;
+	// exports org.hibernate.models.bytebuddy.internal.values;
+
+	provides org.hibernate.models.spi.ModelsContextProvider with
+		org.hibernate.models.bytebuddy.internal.ByteBuddyContextProvider;
+
+}

--- a/hibernate-models-jandex/src/main/java/module-info.java
+++ b/hibernate-models-jandex/src/main/java/module-info.java
@@ -1,0 +1,15 @@
+module org.hibernate.models.jandex {
+	requires org.jboss.jandex;
+	requires org.jboss.logging;
+
+	requires transitive org.hibernate.models;
+
+	exports org.hibernate.models.jandex;
+	exports org.hibernate.models.jandex.spi;
+	// exports org.hibernate.models.jandex.internal;
+	// exports org.hibernate.models.jandex.internal.values;
+
+	provides org.hibernate.models.spi.ModelsContextProvider with
+		org.hibernate.models.jandex.internal.JandexModelsContextProvider;
+
+}

--- a/hibernate-models/src/main/java/module-info.java
+++ b/hibernate-models/src/main/java/module-info.java
@@ -1,0 +1,21 @@
+module org.hibernate.models {
+	requires java.sql;
+	requires org.jboss.logging;
+
+	exports org.hibernate.models;
+	exports org.hibernate.models.rendering;
+	exports org.hibernate.models.rendering.spi;
+	exports org.hibernate.models.serial.spi;
+	exports org.hibernate.models.spi;
+
+	// TODO: have the "shared classes" in the SPI packages, instead of exporting "internal" packages
+	//  (even if it's to a limited number of own modules) ?
+	exports org.hibernate.models.internal.util to org.hibernate.models.bytebuddy, org.hibernate.models.jandex, org.hibernate.orm.core;
+	exports org.hibernate.models.internal to org.hibernate.models.bytebuddy, org.hibernate.models.jandex, org.hibernate.orm.core;
+	exports org.hibernate.models.internal.jdk to org.hibernate.models.bytebuddy, org.hibernate.models.jandex, org.hibernate.orm.core;
+	exports org.hibernate.models.serial.internal to org.hibernate.models.bytebuddy, org.hibernate.models.jandex, org.hibernate.orm.core;
+	exports org.hibernate.models.internal.dynamic to org.hibernate.orm.core;
+	exports org.hibernate.models.rendering.internal to org.hibernate.orm.core;
+
+	uses org.hibernate.models.spi.ModelsContextProvider;
+}

--- a/hibernate-models/src/main/java/module-info.java
+++ b/hibernate-models/src/main/java/module-info.java
@@ -10,12 +10,12 @@ module org.hibernate.models {
 
 	// TODO: have the "shared classes" in the SPI packages, instead of exporting "internal" packages
 	//  (even if it's to a limited number of own modules) ?
-	exports org.hibernate.models.internal.util to org.hibernate.models.bytebuddy, org.hibernate.models.jandex, org.hibernate.orm.core;
-	exports org.hibernate.models.internal to org.hibernate.models.bytebuddy, org.hibernate.models.jandex, org.hibernate.orm.core;
-	exports org.hibernate.models.internal.jdk to org.hibernate.models.bytebuddy, org.hibernate.models.jandex, org.hibernate.orm.core;
-	exports org.hibernate.models.serial.internal to org.hibernate.models.bytebuddy, org.hibernate.models.jandex, org.hibernate.orm.core;
-	exports org.hibernate.models.internal.dynamic to org.hibernate.orm.core;
-	exports org.hibernate.models.rendering.internal to org.hibernate.orm.core;
+	exports org.hibernate.models.internal.util to org.hibernate.models.bytebuddy, org.hibernate.models.jandex, org.hibernate.orm.core, org.hibernate.orm.envers;
+	exports org.hibernate.models.internal to org.hibernate.models.bytebuddy, org.hibernate.models.jandex, org.hibernate.orm.core, org.hibernate.orm.envers;
+	exports org.hibernate.models.internal.jdk to org.hibernate.models.bytebuddy, org.hibernate.models.jandex, org.hibernate.orm.core, org.hibernate.orm.envers;
+	exports org.hibernate.models.serial.internal to org.hibernate.models.bytebuddy, org.hibernate.models.jandex, org.hibernate.orm.core, org.hibernate.orm.envers;
+	exports org.hibernate.models.internal.dynamic to org.hibernate.orm.core, org.hibernate.orm.envers;
+	exports org.hibernate.models.rendering.internal to org.hibernate.orm.core, org.hibernate.orm.envers;
 
 	uses org.hibernate.models.spi.ModelsContextProvider;
 }


### PR DESCRIPTION
Opening this one as a draft...

We've tested this with @dreab8 on Hibernate Search and it seems to work... 
There are a few things we probably want to address before moving forward with this:
- some of the internal packages are used by Hibernate ORM and by jandex/bytebuddy modules, so would be best if we move the needed APIs to some spi packages instead of exporting the internals to these modules
- We've looked at a few plugins to generate module infos but those seem quite outdated and non-maintained and were failing for the recent Gradle versions. 

cc: @yrodiere 