### PR TITLE
Track unindexed classes resolved via JDK fallback

### DIFF
--- a/hibernate-models-jandex/src/main/java/org/hibernate/models/jandex/internal/JandexClassDetailsRegistry.java
+++ b/hibernate-models-jandex/src/main/java/org/hibernate/models/jandex/internal/JandexClassDetailsRegistry.java
@@ -4,6 +4,10 @@
  */
 package org.hibernate.models.jandex.internal;
 
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
 import org.hibernate.models.UnknownClassException;
 import org.hibernate.models.internal.AbstractClassDetailsRegistry;
 import org.hibernate.models.internal.jdk.JdkBuilders;
@@ -22,6 +26,7 @@ import org.jboss.jandex.IndexView;
 public class JandexClassDetailsRegistry extends AbstractClassDetailsRegistry {
 	private final IndexView jandexIndex;
 	private final ClassDetailsBuilder classDetailsBuilder;
+	private final Set<String> unindexedClasses = new LinkedHashSet<>();
 
 	public JandexClassDetailsRegistry(IndexView jandexIndex, boolean trackImplementors, ModelsContext context) {
 		super( trackImplementors, context );
@@ -32,6 +37,14 @@ public class JandexClassDetailsRegistry extends AbstractClassDetailsRegistry {
 	@SuppressWarnings("unused")
 	public IndexView getJandexIndex() {
 		return jandexIndex;
+	}
+
+	/**
+	 * Returns the set of class names that were not found in the Jandex index
+	 * and were resolved via JDK reflection instead.
+	 */
+	public Set<String> getUnindexedClasses() {
+		return Collections.unmodifiableSet( unindexedClasses );
 	}
 
 	@Override
@@ -49,6 +62,7 @@ public class JandexClassDetailsRegistry extends AbstractClassDetailsRegistry {
 
 		final JdkClassDetails jdkClassDetails = JdkBuilders.DEFAULT_BUILDER.buildClassDetails( name, context );
 		if ( jdkClassDetails != null ) {
+			unindexedClasses.add( name );
 			addClassDetails( name, jdkClassDetails );
 			return jdkClassDetails;
 		}


### PR DESCRIPTION
## Summary
- When a class is not found in the Jandex index but is resolved via JDK reflection, record it in a set accessible via `getUnindexedClasses()`
- This allows consumers (like Quarkus) to detect classes missing from the index without losing the JDK fallback behavior

## Test plan
- [ ] Verify existing hibernate-models tests pass
- [ ] Verify Quarkus integration that calls `getUnindexedClasses()` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)