### PR TITLE
Gracefully skip unloadable annotations in AnnotationUsageBuilder

### DIFF
--- a/hibernate-models-jandex/src/main/java/org/hibernate/models/jandex/internal/AnnotationUsageBuilder.java
+++ b/hibernate-models-jandex/src/main/java/org/hibernate/models/jandex/internal/AnnotationUsageBuilder.java
@@ -27,6 +27,8 @@ import org.hibernate.models.spi.ModelsContext;
 import org.jboss.jandex.AnnotationInstance;
 import org.jboss.jandex.DotName;
 
+import static org.hibernate.models.internal.ModelsAnnotationLogging.MODELS_ANNOTATION_LOGGER;
+
 /**
  * Helper for building annotation usages/instances based on
  * Jandex {@linkplain AnnotationInstance} references
@@ -74,17 +76,23 @@ public class AnnotationUsageBuilder {
 				continue;
 			}
 
-			final Class<? extends Annotation> annotationType = modelsContext
-					.getClassLoading()
-					.classForName( annotation.name().toString() );
-
-			final AnnotationDescriptor<?> annotationDescriptor = annotationDescriptorRegistry.getDescriptor( annotationType );
-			final Annotation usage = makeUsage(
-					annotation,
-					annotationDescriptor,
-					modelsContext
-			);
-			consumer.accept( annotationType, usage );
+			try {
+				final Class<? extends Annotation> annotationType = modelsContext
+						.getClassLoading()
+						.classForName( annotation.name().toString() );
+				final AnnotationDescriptor<?> annotationDescriptor = annotationDescriptorRegistry.getDescriptor( annotationType );
+				final Annotation usage = makeUsage( annotation, annotationDescriptor, modelsContext );
+				consumer.accept( annotationType, usage );
+			}
+			catch (Exception e) {
+				// Skip annotations that cannot be loaded or proxied (e.g. non-public annotation
+				// interfaces from transitive dependencies not accessible to this classloader)
+				MODELS_ANNOTATION_LOGGER.debugf(
+						"Skipping annotation [%s]: %s",
+						annotation.name(),
+						e.getMessage()
+				);
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- When iterating annotations on a class, `classForName()` or proxy creation can fail for non-public annotation interfaces from transitive dependencies
- Instead of crashing, catch the exception and log at DEBUG level, allowing `forEachClassDetails` to safely process all classes in the registry
- **Draft:** This changes behavior significantly — may need a feature flag to opt in. Opening for team discussion.

## Test plan
- [ ] Discuss with team whether this should be behind a configuration flag
- [ ] Verify existing tests still pass
- [ ] Add test for unloadable annotation scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)