### PR TITLE
Fix array type details' class when resolving generic types

### DIFF
--- a/hibernate-models-jandex/src/main/java/org/hibernate/models/jandex/internal/JandexMethodDetails.java
+++ b/hibernate-models-jandex/src/main/java/org/hibernate/models/jandex/internal/JandexMethodDetails.java
@@ -129,17 +129,17 @@ public class JandexMethodDetails extends AbstractAnnotationTarget implements Met
 	}
 
 	@Override
-	public TypeDetails resolveRelativeType(TypeVariableScope container) {
+	public TypeDetails resolveRelativeType(TypeVariableScope container, ModelsContext modelsContext) {
 		if ( methodKind == GETTER || methodKind == SETTER ) {
-			return type.determineRelativeType( container );
+			return type.determineRelativeType( container, modelsContext );
 		}
 		throw new IllegalStateException( "Method does not have a type - " + this );
 	}
 
 	@Override
-	public ClassBasedTypeDetails resolveRelativeClassType(TypeVariableScope container) {
+	public ClassBasedTypeDetails resolveRelativeClassType(TypeVariableScope container, ModelsContext modelsContext) {
 		if ( methodKind == GETTER || methodKind == SETTER ) {
-			return TypeDetailsHelper.resolveRelativeClassType( type, container );
+			return TypeDetailsHelper.resolveRelativeClassType( type, container, modelsContext );
 		}
 		throw new IllegalStateException( "Method does not have a type - " + this );
 	}

--- a/hibernate-models/src/main/java/org/hibernate/models/internal/dynamic/DynamicFieldDetails.java
+++ b/hibernate-models/src/main/java/org/hibernate/models/internal/dynamic/DynamicFieldDetails.java
@@ -132,7 +132,7 @@ public class DynamicFieldDetails extends AbstractAnnotationTarget implements Fie
 	}
 
 	@Override
-	public TypeDetails resolveRelativeType(TypeVariableScope container) {
+	public TypeDetails resolveRelativeType(TypeVariableScope container, ModelsContext modelsContext) {
 		return type;
 	}
 

--- a/hibernate-models/src/main/java/org/hibernate/models/internal/jdk/JdkMethodDetails.java
+++ b/hibernate-models/src/main/java/org/hibernate/models/internal/jdk/JdkMethodDetails.java
@@ -139,18 +139,18 @@ public class JdkMethodDetails extends AbstractJdkAnnotationTarget implements Met
 	}
 
 	@Override
-	public TypeDetails resolveRelativeType(TypeVariableScope container) {
+	public TypeDetails resolveRelativeType(TypeVariableScope container, ModelsContext modelsContext) {
 		if ( methodKind == GETTER || methodKind == SETTER ) {
-			return type.determineRelativeType( container );
+			return type.determineRelativeType( container, modelsContext );
 		}
 
 		throw new IllegalStateException( "Method does not have a type - " + this );
 	}
 
 	@Override
-	public ClassBasedTypeDetails resolveRelativeClassType(TypeVariableScope container) {
+	public ClassBasedTypeDetails resolveRelativeClassType(TypeVariableScope container, ModelsContext modelsContext) {
 		if ( methodKind == GETTER || methodKind == SETTER ) {
-			return TypeDetailsHelper.resolveRelativeClassType( type, container );
+			return TypeDetailsHelper.resolveRelativeClassType( type, container, modelsContext );
 		}
 		throw new IllegalStateException( "Method does not have a type - " + this );
 	}

--- a/hibernate-models/src/main/java/org/hibernate/models/spi/MemberDetails.java
+++ b/hibernate-models/src/main/java/org/hibernate/models/spi/MemberDetails.java
@@ -242,29 +242,29 @@ public interface MemberDetails extends AnnotationTarget {
 	 * @apiNote It is only valid to call this on members which have a type, i.e. fields,
 	 * getters, setters and record components.
 	 */
-	default TypeDetails resolveRelativeType(TypeVariableScope container) {
-		return getType().determineRelativeType( container );
+	default TypeDetails resolveRelativeType(TypeVariableScope container, ModelsContext modelsContext) {
+		return getType().determineRelativeType( container, modelsContext );
 	}
 
 	/**
-	 * Same as {@link #resolveRelativeType(TypeVariableScope)}, but for the
+	 * Same as {@link #resolveRelativeType(TypeVariableScope, ModelsContext)}, but for the
 	 * {@linkplain #getAssociatedType() associated type}.
 	 *
 	 * @see #getAssociatedType()
-	 * @see #resolveRelativeType(TypeVariableScope)
+	 * @see #resolveRelativeType(TypeVariableScope, ModelsContext)
 	 */
-	default TypeDetails resolveRelativeAssociatedType(TypeVariableScope container) {
-		return getAssociatedType().determineRelativeType( container );
+	default TypeDetails resolveRelativeAssociatedType(TypeVariableScope container, ModelsContext modelsContext) {
+		return getAssociatedType().determineRelativeType( container, modelsContext );
 	}
 
 	/**
 	 * Determine the concrete class of the member relative to the given {@code container} type.
 	 * <p/>
-	 * Similar to {@linkplain #resolveRelativeType(TypeVariableScope)}, but fully resolving the result
+	 * Similar to {@linkplain #resolveRelativeType(TypeVariableScope, ModelsContext)}, but fully resolving the result
 	 * into the concrete class.
 	 */
-	default ClassBasedTypeDetails resolveRelativeClassType(TypeVariableScope container) {
-		return TypeDetailsHelper.resolveRelativeClassType( getType(), container );
+	default ClassBasedTypeDetails resolveRelativeClassType(TypeVariableScope container, ModelsContext modelsContext) {
+		return TypeDetailsHelper.resolveRelativeClassType( getType(), container, modelsContext );
 	}
 
 

--- a/hibernate-models/src/main/java/org/hibernate/models/spi/TypeDetails.java
+++ b/hibernate-models/src/main/java/org/hibernate/models/spi/TypeDetails.java
@@ -118,8 +118,8 @@ public interface TypeDetails extends TypeVariableScope {
 	 *     <li>Passing {@code AnotherThing}, the result would be {@code ClassTypeDetails(Integer)}</li>
 	 * </ul>
 	 */
-	default TypeDetails determineRelativeType(TypeVariableScope container) {
-		return TypeDetailsHelper.resolveRelativeType( this, container );
+	default TypeDetails determineRelativeType(TypeVariableScope container, ModelsContext modelsContext) {
+		return TypeDetailsHelper.resolveRelativeType( this, container, modelsContext );
 	}
 
 	@Override

--- a/hibernate-models/src/main/java/org/hibernate/models/spi/TypeDetailsHelper.java
+++ b/hibernate-models/src/main/java/org/hibernate/models/spi/TypeDetailsHelper.java
@@ -38,17 +38,21 @@ public class TypeDetailsHelper {
 	 * will return {@code ClassTypeDetails(Integer)}.  A call to resolve the type of {@code id}
 	 * relative to {@code Item} returns {@code ParameterizedTypeDetails(T)} (roughly Object)
 	 */
-	public static TypeDetails resolveRelativeType(TypeDetails type, TypeVariableScope container) {
+	public static TypeDetails resolveRelativeType(
+			TypeDetails type,
+			TypeVariableScope container,
+			ModelsContext modelsContext) {
 		switch ( type.getTypeKind() ) {
 			case CLASS, PRIMITIVE, VOID, WILDCARD_TYPE -> {
 				return type;
 			}
 			case ARRAY -> {
-				final ArrayTypeDetails arrayType = type.asArrayType();
-				return new ArrayTypeDetailsImpl(
-						arrayType.getArrayClassDetails(),
-						arrayType.getConstituentType().determineRelativeType( container )
-				);
+				final TypeDetails constituentType = type.asArrayType().getConstituentType();
+				final TypeDetails resolved = constituentType
+						.determineRelativeType( container, modelsContext );
+				return resolved != constituentType
+						? arrayOf( resolved, modelsContext )
+						: type;
 			}
 			case PARAMETERIZED_TYPE -> {
 				final ParameterizedTypeDetails parameterizedType = type.asParameterizedType();
@@ -59,7 +63,7 @@ public class TypeDetailsHelper {
 				else {
 					resolvedArguments = arrayList( parameterizedType.getArguments().size() );
 					for ( TypeDetails argument : parameterizedType.getArguments() ) {
-						resolvedArguments.add( argument.determineRelativeType( container ) );
+						resolvedArguments.add( argument.determineRelativeType( container, modelsContext ) );
 					}
 				}
 				return new ParameterizedTypeDetailsImpl(
@@ -94,16 +98,20 @@ public class TypeDetailsHelper {
 	}
 
 	/**
-	 * Very much the same as {@linkplain #resolveRelativeType(TypeDetails, TypeVariableScope)}, except that
+	 * Very much the same as {@linkplain #resolveRelativeType(TypeDetails, TypeVariableScope, ModelsContext)}, except that
 	 * here we resolve the relative type to the corresponding {@link ClassBasedTypeDetails} which
 	 * gives easy access to the type's {@linkplain ClassBasedTypeDetails#getClassDetails() ClassDetails}
 	 */
 	public static ClassBasedTypeDetails resolveRelativeClassType(
 			TypeDetails memberType,
-			TypeVariableScope containerType) {
+			TypeVariableScope containerType,
+			ModelsContext modelsContext) {
 		switch ( memberType.getTypeKind() ) {
-			case CLASS, PRIMITIVE, VOID, ARRAY -> {
+			case CLASS, PRIMITIVE, VOID -> {
 				return (ClassBasedTypeDetails) memberType;
+			}
+			case ARRAY -> {
+				return (ClassBasedTypeDetails) resolveRelativeType( memberType, containerType, modelsContext );
 			}
 			case TYPE_VARIABLE -> {
 				final TypeVariableDetails typeVariable = memberType.asTypeVariable();
@@ -133,7 +141,7 @@ public class TypeDetailsHelper {
 				throw new UnsupportedOperationException( "TypeVariableReferenceDetails not supported for relative class resolution" );
 			}
 			case PARAMETERIZED_TYPE, WILDCARD_TYPE -> {
-				return resolveRelativeType( memberType, containerType ).asClassType();
+				return resolveRelativeType( memberType, containerType, modelsContext ).asClassType();
 			}
 			default -> {
 				throw new UnsupportedOperationException( "Unknown TypeDetails kind - " + memberType.getTypeKind() );

--- a/hibernate-models/src/test/java/org/hibernate/models/testing/tests/annotations/MapKeyTest.java
+++ b/hibernate-models/src/test/java/org/hibernate/models/testing/tests/annotations/MapKeyTest.java
@@ -41,11 +41,11 @@ public class MapKeyTest {
 		assertThat( idFieldType.isResolved() ).isTrue();
 
 		FieldDetails mapKeyField = schoolClassDetails.findFieldByName( "studentsByDate" );
-		TypeDetails typeDetails = mapKeyField.resolveRelativeType( schoolClassDetails );
+		TypeDetails typeDetails = mapKeyField.resolveRelativeType( schoolClassDetails, modelsContext );
 		assertThat( typeDetails.isResolved() ).isTrue();
 
 		FieldDetails mapKeyField2 = schoolClassDetails.findFieldByName( "teachersByDate" );
-		TypeDetails typeDetails2 = mapKeyField2.resolveRelativeType( schoolClassDetails );
+		TypeDetails typeDetails2 = mapKeyField2.resolveRelativeType( schoolClassDetails, modelsContext );
 		assertThat( typeDetails2.isResolved() ).isFalse();
 	}
 

--- a/hibernate-models/src/test/java/org/hibernate/models/testing/tests/classes/GenericsTests.java
+++ b/hibernate-models/src/test/java/org/hibernate/models/testing/tests/classes/GenericsTests.java
@@ -49,11 +49,11 @@ public class GenericsTests {
 		assertThat( wrappedType.determineRawClass().isResolved() ).isTrue();
 
 		final ClassDetails thing1ClassDetails = classDetailsRegistry.resolveClassDetails( Thing1.class.getName() );
-		final TypeDetails thing1IdType = idType.determineRelativeType( thing1ClassDetails );
+		final TypeDetails thing1IdType = idType.determineRelativeType( thing1ClassDetails, modelsContext );
 		assertThat( thing1IdType.isResolved() ).isTrue();
 
 		final ClassDetails thing2ClassDetails = classDetailsRegistry.resolveClassDetails( Thing2.class.getName() );
-		final TypeDetails thing2IdType = idType.determineRelativeType( thing2ClassDetails );
+		final TypeDetails thing2IdType = idType.determineRelativeType( thing2ClassDetails, modelsContext );
 		assertThat( thing2IdType.isResolved() ).isTrue();
 	}
 
@@ -74,11 +74,11 @@ public class GenericsTests {
 		assertThat( idType.determineRawClass().isResolved() ).isTrue();
 
 		final ClassDetails thing3ClassDetails = classDetailsRegistry.resolveClassDetails( Thing3.class.getName() );
-		final TypeDetails thing3IdType = idType.determineRelativeType( thing3ClassDetails );
+		final TypeDetails thing3IdType = idType.determineRelativeType( thing3ClassDetails, modelsContext );
 		assertThat( thing3IdType.isResolved() ).isTrue();
 
 		final ClassDetails thing4ClassDetails = classDetailsRegistry.resolveClassDetails( Thing4.class.getName() );
-		final TypeDetails thing4IdType = idType.determineRelativeType( thing4ClassDetails );
+		final TypeDetails thing4IdType = idType.determineRelativeType( thing4ClassDetails, modelsContext );
 		assertThat( thing4IdType.isResolved() ).isTrue();
 	}
 
@@ -102,7 +102,7 @@ public class GenericsTests {
 		assertThat( genericArrayType.determineRawClass().isResolved() ).isTrue();
 
 		final ClassDetails thing5ClassDetails = classDetailsRegistry.getClassDetails( Thing5.class.getName() );
-		final TypeDetails thing5GenericArrayType = genericArrayType.determineRelativeType( thing5ClassDetails );
+		final TypeDetails thing5GenericArrayType = genericArrayType.determineRelativeType( thing5ClassDetails, modelsContext );
 		assertThat( thing5GenericArrayType.isResolved() ).isTrue();
 		assertThat( thing5GenericArrayType.determineRawClass().isResolved() ).isTrue();
 

--- a/hibernate-models/src/test/java/org/hibernate/models/testing/tests/generics/ArrayTypeVariableTests.java
+++ b/hibernate-models/src/test/java/org/hibernate/models/testing/tests/generics/ArrayTypeVariableTests.java
@@ -1,0 +1,172 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.models.testing.tests.generics;
+
+import java.io.Serializable;
+
+import org.hibernate.models.spi.ArrayTypeDetails;
+import org.hibernate.models.spi.ClassBasedTypeDetails;
+import org.hibernate.models.spi.TypeDetails;
+import org.hibernate.models.spi.TypeVariableDetails;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.models.testing.TestHelper.createModelContext;
+
+public class ArrayTypeVariableTests {
+
+	@Test
+	void testParameterizedHierarchy() {
+		final var modelsContext = createModelContext(
+				Root.class,
+				Base1.class,
+				Base2.class,
+				Child2.class
+		);
+
+		final var rootClassDetails = modelsContext.getClassDetailsRegistry().getClassDetails( Root.class.getName() );
+		final var base1ClassDetails = modelsContext.getClassDetailsRegistry().getClassDetails( Base1.class.getName() );
+		final var base2ClassDetails = modelsContext.getClassDetailsRegistry().getClassDetails( Base2.class.getName() );
+		final var child2ClassDetails = modelsContext.getClassDetailsRegistry().getClassDetails( Child2.class.getName() );
+
+		final var rootArrayField = rootClassDetails.findFieldByName( "rootArray" );
+		final var rootArrayFieldType = rootArrayField.getType();
+		assertThat( rootArrayFieldType.getTypeKind() ).isEqualTo( TypeDetails.Kind.ARRAY );
+		assertThat( rootArrayFieldType.isResolved() ).isFalse();
+
+		final var constituentType = rootArrayFieldType.asArrayType().getConstituentType();
+		assertThat( constituentType.getTypeKind() ).isEqualTo( TypeDetails.Kind.TYPE_VARIABLE );
+		assertThat( constituentType.isResolved() ).isFalse();
+
+		{
+			// array type
+			final var resolvedRelativeType = rootArrayField.resolveRelativeType( rootClassDetails, modelsContext );
+			assertThat( resolvedRelativeType.isResolved() ).isFalse();
+			assertThat( resolvedRelativeType ).isInstanceOf( ArrayTypeDetails.class );
+			final var resolvedArrayType = resolvedRelativeType.asArrayType();
+			assertThat( resolvedArrayType.getArrayClassDetails().toJavaClass() ).isEqualTo( Object[].class );
+
+			// constituent type
+			final var resolvedConstituentType = resolvedArrayType.getConstituentType();
+			assertThat( resolvedConstituentType.isResolved() ).isFalse();
+			assertThat( resolvedConstituentType ).isInstanceOf( TypeVariableDetails.class );
+			final TypeDetails bound = resolvedConstituentType.asTypeVariable().getBounds().get( 0 );
+			assertThat( bound.getTypeKind() ).isEqualTo( TypeDetails.Kind.CLASS );
+			assertThat( bound.asClassType().getClassDetails().toJavaClass() ).isEqualTo( Object.class );
+
+			// array type as class type
+			final ClassBasedTypeDetails resolvedClassType = rootArrayField.resolveRelativeClassType( rootClassDetails, modelsContext );
+			assertThat( resolvedClassType.isResolved() ).isFalse();
+			assertThat( resolvedClassType.getClassDetails().toJavaClass() ).isEqualTo( Object[].class );
+		}
+
+		{
+			// Base1 specializes Root<Integer>, so rootArray should resolve to Integer[]
+			final var concreteType = rootArrayField.resolveRelativeType( base1ClassDetails, modelsContext );
+			assertThat( concreteType.isResolved() ).isTrue();
+			assertThat( concreteType ).isInstanceOf( ArrayTypeDetails.class );
+			final var concreteArrayDetails = concreteType.asArrayType();
+			assertThat( concreteArrayDetails.getArrayClassDetails().toJavaClass() ).isEqualTo( Integer[].class );
+
+			// constituent type
+			final var concreteConstituentType = concreteArrayDetails.getConstituentType();
+			assertThat( concreteConstituentType.isResolved() ).isTrue();
+			assertThat( concreteConstituentType ).isInstanceOf( ClassBasedTypeDetails.class );
+			assertThat( concreteConstituentType.asClassType().getClassDetails().toJavaClass() ).isEqualTo( Integer.class );
+
+			// array type as class type
+			final var resolvedClassType = rootArrayField.resolveRelativeClassType( base1ClassDetails, modelsContext );
+			assertThat( resolvedClassType.isResolved() ).isTrue();
+			assertThat( resolvedClassType.getClassDetails().toJavaClass() ).isEqualTo( Integer[].class );
+		}
+
+		{
+			// Base2 specializes Root<String>, so rootArray should resolve to String[]
+			final var concreteType = rootArrayField.resolveRelativeType( base2ClassDetails, modelsContext );
+			assertThat( concreteType.isResolved() ).isTrue();
+			assertThat( concreteType ).isInstanceOf( ArrayTypeDetails.class );
+			final var concreteArrayDetails = concreteType.asArrayType();
+			assertThat( concreteArrayDetails.getArrayClassDetails().toJavaClass() ).isEqualTo( String[].class );
+
+			// constituent type
+			final var concreteConstituentType = concreteArrayDetails.getConstituentType();
+			assertThat( concreteConstituentType.isResolved() ).isTrue();
+			assertThat( concreteConstituentType ).isInstanceOf( ClassBasedTypeDetails.class );
+			assertThat( concreteConstituentType.asClassType().getClassDetails().toJavaClass() ).isEqualTo( String.class );
+
+			// array type as class type
+			final var resolvedClassType = rootArrayField.resolveRelativeClassType( base2ClassDetails, modelsContext );
+			assertThat( resolvedClassType.isResolved() ).isTrue();
+			assertThat( resolvedClassType.getClassDetails().toJavaClass() ).isEqualTo( String[].class );
+		}
+
+		// Test anotherArray field from Base2
+		final var anotherArrayField = base2ClassDetails.findFieldByName( "anotherArray" );
+		final var anotherArrayFieldType = anotherArrayField.getType();
+		assertThat( anotherArrayFieldType.getTypeKind() ).isEqualTo( TypeDetails.Kind.ARRAY );
+		assertThat( anotherArrayFieldType.isResolved() ).isFalse();
+
+		final var anotherConstituentType = anotherArrayFieldType.asArrayType().getConstituentType();
+		assertThat( anotherConstituentType.getTypeKind() ).isEqualTo( TypeDetails.Kind.TYPE_VARIABLE );
+		assertThat( anotherConstituentType.isResolved() ).isFalse();
+
+		{
+			// In Base2, anotherArray is K[] where K extends Serializable, so unresolved with Serializable bound
+			final var resolvedRelativeType = anotherArrayField.resolveRelativeType( base2ClassDetails, modelsContext );
+			assertThat( resolvedRelativeType.isResolved() ).isFalse();
+			assertThat( resolvedRelativeType ).isInstanceOf( ArrayTypeDetails.class );
+			final var resolvedArrayType = resolvedRelativeType.asArrayType();
+			assertThat( resolvedArrayType.getArrayClassDetails().toJavaClass() ).isEqualTo( Serializable[].class );
+
+			// constituent type
+			final var resolvedConstituentType = resolvedArrayType.getConstituentType();
+			assertThat( resolvedConstituentType.isResolved() ).isFalse();
+			assertThat( resolvedConstituentType ).isInstanceOf( TypeVariableDetails.class );
+			final TypeDetails bound = resolvedConstituentType.asTypeVariable().getBounds().get( 0 );
+			assertThat( bound.getTypeKind() ).isEqualTo( TypeDetails.Kind.CLASS );
+			assertThat( bound.asClassType().getClassDetails().toJavaClass() ).isEqualTo( Serializable.class );
+
+			// array type as class type
+			final ClassBasedTypeDetails resolvedClassType = anotherArrayField.resolveRelativeClassType( base2ClassDetails, modelsContext );
+			assertThat( resolvedClassType.isResolved() ).isFalse();
+			assertThat( resolvedClassType.getClassDetails().toJavaClass() ).isEqualTo( Serializable[].class );
+		}
+
+		{
+			// In Child2, anotherArray should resolve to Long[] since Child2 extends Base2<Long>
+			final var concreteType = anotherArrayField.resolveRelativeType( child2ClassDetails, modelsContext );
+			assertThat( concreteType.isResolved() ).isTrue();
+			assertThat( concreteType ).isInstanceOf( ArrayTypeDetails.class );
+			final var concreteArrayDetails = concreteType.asArrayType();
+			assertThat( concreteArrayDetails.getArrayClassDetails().toJavaClass() ).isEqualTo( Long[].class );
+
+			// constituent type
+			final var concreteConstituentType = concreteArrayDetails.getConstituentType();
+			assertThat( concreteConstituentType.isResolved() ).isTrue();
+			assertThat( concreteConstituentType ).isInstanceOf( ClassBasedTypeDetails.class );
+			assertThat( concreteConstituentType.asClassType().getClassDetails().toJavaClass() ).isEqualTo( Long.class );
+
+			// array type as class type
+			final var resolvedClassType = anotherArrayField.resolveRelativeClassType( child2ClassDetails, modelsContext );
+			assertThat( resolvedClassType.isResolved() ).isTrue();
+			assertThat( resolvedClassType.getClassDetails().toJavaClass() ).isEqualTo( Long[].class );
+		}
+	}
+
+	static class Root<T> {
+		T[] rootArray;
+	}
+
+	static class Base1 extends Root<Integer> {
+	}
+
+	static class Base2<K extends Serializable> extends Root<String> {
+		K[] anotherArray;
+	}
+
+	static class Child2 extends Base2<Long> {
+	}
+}

--- a/hibernate-models/src/test/java/org/hibernate/models/testing/tests/generics/BaselineTests.java
+++ b/hibernate-models/src/test/java/org/hibernate/models/testing/tests/generics/BaselineTests.java
@@ -40,7 +40,7 @@ public class BaselineTests {
 
 		assertThat( classDetails.getTypeParameters() ).isEmpty();
 
-		final TypeDetails idFieldConcreteType = idField.resolveRelativeType( classDetails );
+		final TypeDetails idFieldConcreteType = idField.resolveRelativeType( classDetails, modelsContext );
 		assertThat( idFieldConcreteType ).isInstanceOf( ClassTypeDetails.class );
 		assertThat( ( (ClassTypeDetails) idFieldConcreteType ).getClassDetails().toJavaClass() ).isEqualTo( Integer.class );
 	}

--- a/hibernate-models/src/test/java/org/hibernate/models/testing/tests/generics/InheritanceTypeVariableTests.java
+++ b/hibernate-models/src/test/java/org/hibernate/models/testing/tests/generics/InheritanceTypeVariableTests.java
@@ -48,49 +48,49 @@ public class InheritanceTypeVariableTests {
 		assertThat( idFieldType.isResolved() ).isFalse();
 
 		{
-			final TypeDetails resolvedRelativeType = idField.resolveRelativeType( rootClassDetails );
+			final TypeDetails resolvedRelativeType = idField.resolveRelativeType( rootClassDetails, modelsContext );
 			assertThat( resolvedRelativeType.isResolved() ).isFalse();
 			assertThat( resolvedRelativeType ).isInstanceOf( TypeVariableDetails.class );
 			final TypeDetails bound = ( (TypeVariableDetails) resolvedRelativeType ).getBounds().get( 0 );
 			assertThat( bound.getTypeKind() ).isEqualTo( TypeDetails.Kind.CLASS );
 			assertThat( bound.asClassType().getClassDetails().toJavaClass() ).isEqualTo( Object.class );
 
-			final ClassBasedTypeDetails resolvedClassType = idField.resolveRelativeClassType( rootClassDetails );
+			final ClassBasedTypeDetails resolvedClassType = idField.resolveRelativeClassType( rootClassDetails, modelsContext );
 			assertThat( idField.getType().isResolved() ).isFalse();
 			assertThat( resolvedClassType.getClassDetails().toJavaClass() ).isEqualTo( Object.class );
 		}
 
 		{
-			final TypeDetails concreteType = idField.resolveRelativeType( base1ClassDetails );
+			final TypeDetails concreteType = idField.resolveRelativeType( base1ClassDetails, modelsContext );
 			assertThat( concreteType ).isInstanceOf( ClassTypeDetails.class );
 			final ClassDetails concreteClassDetails = ( (ClassTypeDetails) concreteType ).getClassDetails();
 			assertThat( concreteClassDetails.toJavaClass() ).isEqualTo( Integer.class );
 
-			final ClassBasedTypeDetails resolvedClassType = idField.resolveRelativeClassType( base1ClassDetails );
+			final ClassBasedTypeDetails resolvedClassType = idField.resolveRelativeClassType( base1ClassDetails, modelsContext );
 			assertThat( resolvedClassType.isResolved() ).isTrue();
 			assertThat( resolvedClassType.getClassDetails().toJavaClass() ).isEqualTo( Integer.class );
 			assertThat( resolvedClassType.isResolved() ).isTrue();
 		}
 
 		{
-			final TypeDetails concreteType = idField.resolveRelativeType( base2ClassDetails );
+			final TypeDetails concreteType = idField.resolveRelativeType( base2ClassDetails, modelsContext );
 			assertThat( concreteType ).isInstanceOf( ClassTypeDetails.class );
 			final ClassDetails concreteClassDetails = ( (ClassTypeDetails) concreteType ).getClassDetails();
 			assertThat( concreteClassDetails.toJavaClass() ).isEqualTo( String.class );
 
-			final ClassBasedTypeDetails resolvedClassType = idField.resolveRelativeClassType( base2ClassDetails );
+			final ClassBasedTypeDetails resolvedClassType = idField.resolveRelativeClassType( base2ClassDetails, modelsContext );
 			assertThat( resolvedClassType.isResolved() ).isTrue();
 			assertThat( resolvedClassType.getClassDetails().toJavaClass() ).isEqualTo( String.class );
 			assertThat( resolvedClassType.isResolved() ).isTrue();
 		}
 
 		{
-			final TypeDetails concreteType = idField.resolveRelativeType( base3ClassDetails );
+			final TypeDetails concreteType = idField.resolveRelativeType( base3ClassDetails, modelsContext );
 			assertThat( concreteType ).isInstanceOf( ClassTypeDetails.class );
 			final ClassDetails concreteClassDetails = ( (ClassTypeDetails) concreteType ).getClassDetails();
 			assertThat( concreteClassDetails.toJavaClass() ).isEqualTo( Long.class );
 
-			final ClassBasedTypeDetails resolvedClassType = idField.resolveRelativeClassType( base3ClassDetails );
+			final ClassBasedTypeDetails resolvedClassType = idField.resolveRelativeClassType( base3ClassDetails, modelsContext );
 			assertThat( resolvedClassType.isResolved() ).isTrue();
 			assertThat( resolvedClassType.getClassDetails().toJavaClass() ).isEqualTo( Long.class );
 			assertThat( resolvedClassType.isResolved() ).isTrue();
@@ -103,12 +103,12 @@ public class InheritanceTypeVariableTests {
 			assertThat( middleFieldType.getTypeKind() ).isEqualTo( TypeDetails.Kind.TYPE_VARIABLE );
 			assertThat( middleFieldType.isResolved() ).isFalse();
 
-			final TypeDetails concreteType = middleField.resolveRelativeType( base3ClassDetails );
+			final TypeDetails concreteType = middleField.resolveRelativeType( base3ClassDetails, modelsContext );
 			assertThat( concreteType ).isInstanceOf( ClassTypeDetails.class );
 			final ClassDetails concreteClassDetails = ( (ClassTypeDetails) concreteType ).getClassDetails();
 			assertThat( concreteClassDetails.toJavaClass() ).isEqualTo( Short.class );
 
-			final ClassBasedTypeDetails resolvedClassType = middleField.resolveRelativeClassType( base3ClassDetails );
+			final ClassBasedTypeDetails resolvedClassType = middleField.resolveRelativeClassType( base3ClassDetails, modelsContext );
 			assertThat( resolvedClassType.isResolved() ).isTrue();
 			assertThat( resolvedClassType.getClassDetails().toJavaClass() ).isEqualTo( Short.class );
 			assertThat( resolvedClassType.isResolved() ).isTrue();

--- a/hibernate-models/src/test/java/org/hibernate/models/testing/tests/generics/NestedInheritanceTest.java
+++ b/hibernate-models/src/test/java/org/hibernate/models/testing/tests/generics/NestedInheritanceTest.java
@@ -40,7 +40,7 @@ public class NestedInheritanceTest {
 		assertThat( baseFieldType.isResolved() ).isFalse();
 
 		{
-			final TypeDetails resolvedRelativeType = base.resolveRelativeType( baseClassDetails );
+			final TypeDetails resolvedRelativeType = base.resolveRelativeType( baseClassDetails, modelsContext );
 			assertThat( resolvedRelativeType.isResolved() ).isFalse();
 			assertThat( resolvedRelativeType ).isInstanceOf( TypeVariableDetails.class );
 		}
@@ -51,23 +51,23 @@ public class NestedInheritanceTest {
 		assertThat( oneFieldType.isResolved() ).isFalse();
 
 		{
-			final TypeDetails concreteType = base.resolveRelativeType( intermediateClassDetails );
+			final TypeDetails concreteType = base.resolveRelativeType( intermediateClassDetails, modelsContext );
 			assertThat( concreteType ).isInstanceOf( ClassTypeDetails.class );
 			final ClassDetails concreteClassDetails = ( (ClassTypeDetails) concreteType ).getClassDetails();
 			assertThat( concreteClassDetails.toJavaClass() ).isEqualTo( Integer.class );
 
-			final TypeDetails intermediateConcreteType = one.resolveRelativeType( intermediateClassDetails );
+			final TypeDetails intermediateConcreteType = one.resolveRelativeType( intermediateClassDetails, modelsContext );
 			assertThat( intermediateConcreteType.isResolved() ).isFalse();
 			assertThat( intermediateConcreteType ).isInstanceOf( TypeVariableDetails.class );
 		}
 
 		{
-			final TypeDetails baseConcreteType = base.resolveRelativeType( leafClassDetails );
+			final TypeDetails baseConcreteType = base.resolveRelativeType( leafClassDetails, modelsContext );
 			assertThat( baseConcreteType ).isInstanceOf( ClassTypeDetails.class );
 			final ClassDetails concreteClassDetails = ( (ClassTypeDetails) baseConcreteType ).getClassDetails();
 			assertThat( concreteClassDetails.toJavaClass() ).isEqualTo( Integer.class );
 
-			final TypeDetails intermediateConcreteType = one.resolveRelativeType( leafClassDetails );
+			final TypeDetails intermediateConcreteType = one.resolveRelativeType( leafClassDetails, modelsContext );
 			assertThat( intermediateConcreteType ).isInstanceOf( ClassTypeDetails.class );
 			final ClassDetails intermediateConcreteClassDetails = ( (ClassTypeDetails) intermediateConcreteType ).getClassDetails();
 			assertThat( intermediateConcreteClassDetails.toJavaClass() ).isEqualTo( String.class );

--- a/hibernate-models/src/test/java/org/hibernate/models/testing/tests/generics/NestedRecursiveInheritanceTest.java
+++ b/hibernate-models/src/test/java/org/hibernate/models/testing/tests/generics/NestedRecursiveInheritanceTest.java
@@ -47,11 +47,11 @@ public class NestedRecursiveInheritanceTest {
 			assertThat( parentFieldType.getTypeKind() ).isEqualTo( TypeDetails.Kind.TYPE_VARIABLE );
 			assertThat( parentFieldType.determineRawClass().toJavaClass() ).isEqualTo( Parent.class );
 
-			final TypeDetails child2Parent = parentField.resolveRelativeType( child2 );
+			final TypeDetails child2Parent = parentField.resolveRelativeType( child2, modelsContext );
 			assertThat( child2Parent.getTypeKind() ).isEqualTo( TypeDetails.Kind.TYPE_VARIABLE );
 			assertThat( child2Parent.determineRawClass().toJavaClass() ).isEqualTo( ParentHierarchy2.class );
 
-			final TypeDetails child22Parent = parentField.resolveRelativeType( child22 );
+			final TypeDetails child22Parent = parentField.resolveRelativeType( child22, modelsContext );
 			assertThat( child22Parent ).isInstanceOf( ClassTypeDetails.class );
 			assertThat( child22Parent.determineRawClass().toJavaClass() ).isEqualTo( ParentHierarchy22.class );
 		}
@@ -69,11 +69,11 @@ public class NestedRecursiveInheritanceTest {
 			assertThat( childrenFieldType.getTypeKind() ).isEqualTo( TypeDetails.Kind.TYPE_VARIABLE );
 			assertThat( childrenFieldType.determineRawClass().toJavaClass() ).isEqualTo( Child.class );
 
-			final TypeDetails parent2Children = childrenField.resolveRelativeAssociatedType( parent2 );
+			final TypeDetails parent2Children = childrenField.resolveRelativeAssociatedType( parent2, modelsContext );
 			assertThat( parent2Children.getTypeKind() ).isEqualTo( TypeDetails.Kind.TYPE_VARIABLE );
 			assertThat( parent2Children.determineRawClass().toJavaClass() ).isEqualTo( ChildHierarchy2.class );
 
-			final TypeDetails parent22Children = childrenField.resolveRelativeAssociatedType( parent22 );
+			final TypeDetails parent22Children = childrenField.resolveRelativeAssociatedType( parent22, modelsContext );
 			assertThat( parent22Children ).isInstanceOf( ClassTypeDetails.class );
 			assertThat( parent22Children.determineRawClass().toJavaClass() ).isEqualTo( ChildHierarchy22.class );
 		}

--- a/hibernate-models/src/test/java/org/hibernate/models/testing/tests/generics/RecursiveMultipleTypeParametersTests.java
+++ b/hibernate-models/src/test/java/org/hibernate/models/testing/tests/generics/RecursiveMultipleTypeParametersTests.java
@@ -23,7 +23,7 @@ public class RecursiveMultipleTypeParametersTests {
 		);
 
 		final FieldDetails idField = classDetails.findFieldByName( "id" );
-		final TypeDetails idType = idField.resolveRelativeType( classDetails );
+		final TypeDetails idType = idField.resolveRelativeType( classDetails, modelsContext );
 		assertThat( idType.getTypeKind() ).isEqualTo( TypeDetails.Kind.TYPE_VARIABLE );
 		assertThat( idType.isImplementor( Transitionable.class ) ).isTrue();
 	}
@@ -36,7 +36,7 @@ public class RecursiveMultipleTypeParametersTests {
 		);
 
 		final FieldDetails idField = classDetails.findFieldByName( "id" );
-		final TypeDetails idType = idField.resolveRelativeType( classDetails );
+		final TypeDetails idType = idField.resolveRelativeType( classDetails, modelsContext );
 		assertThat( idType.getTypeKind() ).isEqualTo( TypeDetails.Kind.TYPE_VARIABLE );
 		assertThat( idType.isImplementor( Transitionable.class ) ).isTrue();
 	}

--- a/hibernate-models/src/test/java/org/hibernate/models/testing/tests/generics/SimpleTypeVariableTests.java
+++ b/hibernate-models/src/test/java/org/hibernate/models/testing/tests/generics/SimpleTypeVariableTests.java
@@ -43,16 +43,16 @@ public class SimpleTypeVariableTests {
 		assertThat( idFieldType.isImplementor( Object.class ) ).isTrue();
 		assertThat( idFieldType.isImplementor( String.class ) ).isFalse();
 		assertThat( idFieldType.isResolved() ).isFalse();
-		assertThat( idFieldType.determineRelativeType( classDetails ).isResolved() ).isFalse();
+		assertThat( idFieldType.determineRelativeType( classDetails, modelsContext ).isResolved() ).isFalse();
 
-		final TypeDetails idFieldConcreteType = idField.resolveRelativeType( classDetails );
+		final TypeDetails idFieldConcreteType = idField.resolveRelativeType( classDetails, modelsContext );
 		assertThat( idFieldConcreteType ).isInstanceOf( TypeVariableDetails.class );
 		final TypeVariableDetails typeVariable = idFieldConcreteType.asTypeVariable();
 		assertThat( typeVariable.getBounds() ).hasSize( 1 );
 		assertThat( typeVariable.getBounds().get( 0 ).asClassType().getClassDetails().toJavaClass() ).isEqualTo( Number.class );
 		assertThat( idFieldConcreteType.isResolved() ).isFalse();
 
-		final ClassBasedTypeDetails classBasedTypeDetails = idField.resolveRelativeClassType( classDetails );
+		final ClassBasedTypeDetails classBasedTypeDetails = idField.resolveRelativeClassType( classDetails, modelsContext );
 		assertThat( classBasedTypeDetails.getClassDetails().toJavaClass() ).isEqualTo( Number.class );
 	}
 

--- a/hibernate-models/src/test/java/org/hibernate/models/testing/tests/members/UnboundWildcardTests.java
+++ b/hibernate-models/src/test/java/org/hibernate/models/testing/tests/members/UnboundWildcardTests.java
@@ -42,7 +42,7 @@ public class UnboundWildcardTests {
 			assertThat( parentWildcard.isResolved() ).isTrue();
 			assertThat( parentWildcard.determineRawClass().toJavaClass() ).isEqualTo( Object.class );
 
-			final TypeDetails parentRelativeType = parent.resolveRelativeType( classDetails );
+			final TypeDetails parentRelativeType = parent.resolveRelativeType( classDetails, modelsContext );
 			assertThat( parentRelativeType.isResolved() ).isTrue();
 			assertThat( parentRelativeType.determineRawClass().toJavaClass() ).isEqualTo( Thing.class );
 			final WildcardTypeDetails parentRelativeWildcard = parentRelativeType.asParameterizedType()
@@ -68,7 +68,7 @@ public class UnboundWildcardTests {
 			assertThat( childrenWildcard.isResolved() ).isTrue();
 			assertThat( childrenWildcard.determineRawClass().toJavaClass() ).isEqualTo( Object.class );
 
-			final TypeDetails childrenRelativeType = children.resolveRelativeType( classDetails );
+			final TypeDetails childrenRelativeType = children.resolveRelativeType( classDetails, modelsContext );
 			assertThat( childrenRelativeType.isResolved() ).isTrue();
 			assertThat( childrenRelativeType.determineRawClass().toJavaClass() ).isEqualTo( List.class );
 			final ParameterizedTypeDetails listRelativeType = childrenRelativeType.asParameterizedType()


### PR DESCRIPTION
* Fixes #186 

We need the `ModelsContext` to resolve/create the `ClassDetails` for the generic-resolved array type, so I added it as a parameter for all the `resolveRelativeType` SPIs. This means it will be a breaking change for integrators.