### PR TITLE
#263 - Resolve collection and map type arguments through generic type hierarchies

### DIFF
--- a/hibernate-models/src/main/java/org/hibernate/models/internal/CollectionElementSwitch.java
+++ b/hibernate-models/src/main/java/org/hibernate/models/internal/CollectionElementSwitch.java
@@ -4,96 +4,20 @@
  */
 package org.hibernate.models.internal;
 
-import java.util.Collection;
-
-import org.hibernate.models.spi.ClassDetails;
-import org.hibernate.models.spi.ClassTypeDetails;
-import org.hibernate.models.spi.ParameterizedTypeDetails;
 import org.hibernate.models.spi.TypeDetails;
-import org.hibernate.models.spi.TypeVariableDetails;
-import org.hibernate.models.spi.TypeVariableReferenceDetails;
-import org.hibernate.models.spi.WildcardTypeDetails;
-
-import static org.hibernate.models.spi.StandardTypeDetails.OBJECT_TYPE_DETAILS;
+import org.hibernate.models.spi.TypeDetailsHelper;
 
 /**
- * Used to determine the type details for a Collection element - see {@linkplain #extractCollectionElementType(TypeDetails)}
+ * Compatibility bridge for collection element type extraction.
  *
- * @author Steve Ebersole
+ * @deprecated Use {@link TypeDetailsHelper#extractCollectionElementType(TypeDetails)}.
  */
-public class CollectionElementSwitch extends TypeDetailsSwitchSupport<TypeDetails> {
+@Deprecated(since = "1.1", forRemoval = true)
+public class CollectionElementSwitch {
+	private CollectionElementSwitch() {
+	}
 
 	public static TypeDetails extractCollectionElementType(TypeDetails memberType) {
-		assert memberType.isImplementor( Collection.class );
-
-		final ClassDetails rawClassDetails = memberType.determineRawClass();
-		final CollectionElementSwitch collectionElementSwitch = new CollectionElementSwitch( memberType );
-
-		// first, check super-type...
-		if ( rawClassDetails.getGenericSuperType() != null ) {
-			final TypeDetails typeDetails = TypeDetailsSwitcher.switchType( rawClassDetails.getGenericSuperType(), collectionElementSwitch );
-			if ( typeDetails != null ) {
-				return typeDetails;
-			}
-		}
-
-		// then, interfaces...
-		for ( TypeDetails implementedInterface : rawClassDetails.getImplementedInterfaces() ) {
-			final TypeDetails typeDetails = TypeDetailsSwitcher.switchType( implementedInterface, collectionElementSwitch );
-			if ( typeDetails != null ) {
-				return typeDetails;
-			}
-		}
-
-		// otherwise, assume Object
-		return OBJECT_TYPE_DETAILS;
-	}
-
-	private final TypeDetails memberTypeDetails;
-
-	private CollectionElementSwitch(TypeDetails memberTypeDetails) {
-		this.memberTypeDetails = memberTypeDetails;
-	}
-
-	@Override
-	public TypeDetails caseClass(ClassTypeDetails classType) {
-		if ( classType.isImplementor( Collection.class ) ) {
-			if ( classType.getClassDetails().getGenericSuperType() != null ) {
-				return TypeDetailsSwitcher.switchType( classType.getClassDetails().getGenericSuperType(), this );
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public TypeDetails caseParameterizedType(ParameterizedTypeDetails parameterizedType) {
-		if ( parameterizedType.isImplementor( Collection.class ) ) {
-			return parameterizedType.getArguments().get( 0 );
-		}
-		return null;
-	}
-
-	@Override
-	public TypeDetails caseWildcardType(WildcardTypeDetails wildcardType) {
-		if ( wildcardType.isImplementor( Collection.class ) ) {
-			return wildcardType.getBound();
-		}
-		return null;
-	}
-
-	@Override
-	public TypeDetails caseTypeVariable(TypeVariableDetails typeVariable) {
-		if ( typeVariable.isImplementor( Collection.class ) ) {
-			return memberTypeDetails.resolveTypeVariable( typeVariable );
-		}
-		return null;
-	}
-
-	@Override
-	public TypeDetails caseTypeVariableReference(TypeVariableReferenceDetails typeVariableReference) {
-		if ( typeVariableReference.isImplementor( Collection.class ) ) {
-			return memberTypeDetails.resolveTypeVariable( typeVariableReference.getTarget() );
-		}
-		return null;
+		return TypeDetailsHelper.extractCollectionElementType( memberType );
 	}
 }

--- a/hibernate-models/src/main/java/org/hibernate/models/internal/MapKeySwitch.java
+++ b/hibernate-models/src/main/java/org/hibernate/models/internal/MapKeySwitch.java
@@ -4,96 +4,20 @@
  */
 package org.hibernate.models.internal;
 
-import java.util.Map;
-
-import org.hibernate.models.spi.ClassDetails;
-import org.hibernate.models.spi.ClassTypeDetails;
-import org.hibernate.models.spi.ParameterizedTypeDetails;
 import org.hibernate.models.spi.TypeDetails;
-import org.hibernate.models.spi.TypeVariableDetails;
-import org.hibernate.models.spi.TypeVariableReferenceDetails;
-import org.hibernate.models.spi.WildcardTypeDetails;
-
-import static org.hibernate.models.spi.StandardTypeDetails.OBJECT_TYPE_DETAILS;
+import org.hibernate.models.spi.TypeDetailsHelper;
 
 /**
- * Used to determine the type details for a Map key - see {@linkplain #extractMapKeyType(TypeDetails)}
+ * Compatibility bridge for map key type extraction.
  *
- * @author Steve Ebersole
+ * @deprecated Use {@link TypeDetailsHelper#extractMapKeyType(TypeDetails)}.
  */
-public class MapKeySwitch extends TypeDetailsSwitchSupport<TypeDetails> {
+@Deprecated(since = "1.1", forRemoval = true)
+public class MapKeySwitch {
+	private MapKeySwitch() {
+	}
 
 	public static TypeDetails extractMapKeyType(TypeDetails memberType) {
-		assert memberType.isImplementor( Map.class );
-
-		final ClassDetails rawClassDetails = memberType.determineRawClass();
-		final MapKeySwitch mapKeySwitch = new MapKeySwitch( memberType );
-
-		// first, check super-type...
-		if ( rawClassDetails.getGenericSuperType() != null ) {
-			final TypeDetails typeDetails = TypeDetailsSwitcher.switchType( rawClassDetails.getGenericSuperType(), mapKeySwitch );
-			if ( typeDetails != null ) {
-				return typeDetails;
-			}
-		}
-
-		// then, interfaces...
-		for ( TypeDetails implementedInterface : rawClassDetails.getImplementedInterfaces() ) {
-			final TypeDetails typeDetails = TypeDetailsSwitcher.switchType( implementedInterface, mapKeySwitch );
-			if ( typeDetails != null ) {
-				return typeDetails;
-			}
-		}
-
-		// otherwise, assume Object
-		return OBJECT_TYPE_DETAILS;
-	}
-
-	private final TypeDetails memberTypeDetails;
-
-	private MapKeySwitch(TypeDetails memberTypeDetails) {
-		this.memberTypeDetails = memberTypeDetails;
-	}
-
-	@Override
-	public TypeDetails caseClass(ClassTypeDetails classType) {
-		if ( classType.isImplementor( Map.class ) ) {
-			if ( classType.getClassDetails().getGenericSuperType() != null ) {
-				return TypeDetailsSwitcher.switchType( classType.getClassDetails().getGenericSuperType(), this );
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public TypeDetails caseParameterizedType(ParameterizedTypeDetails parameterizedType) {
-		if ( parameterizedType.isImplementor( Map.class ) ) {
-			return parameterizedType.getArguments().get( 0 );
-		}
-		return null;
-	}
-
-	@Override
-	public TypeDetails caseWildcardType(WildcardTypeDetails wildcardType) {
-		if ( wildcardType.isImplementor( Map.class ) ) {
-			return wildcardType.getBound();
-		}
-		return null;
-	}
-
-	@Override
-	public TypeDetails caseTypeVariable(TypeVariableDetails typeVariable) {
-		if ( typeVariable.isImplementor( Map.class ) ) {
-			return memberTypeDetails.resolveTypeVariable( typeVariable );
-		}
-		return null;
-	}
-
-	@Override
-	public TypeDetails caseTypeVariableReference(TypeVariableReferenceDetails typeVariableReference) {
-		if ( typeVariableReference.isImplementor( Map.class ) ) {
-			return memberTypeDetails.resolveTypeVariable( typeVariableReference.getTarget() );
-		}
-		return null;
+		return TypeDetailsHelper.extractMapKeyType( memberType );
 	}
 }

--- a/hibernate-models/src/main/java/org/hibernate/models/internal/MapValueSwitch.java
+++ b/hibernate-models/src/main/java/org/hibernate/models/internal/MapValueSwitch.java
@@ -4,96 +4,20 @@
  */
 package org.hibernate.models.internal;
 
-import java.util.Map;
-
-import org.hibernate.models.spi.ClassDetails;
-import org.hibernate.models.spi.ClassTypeDetails;
-import org.hibernate.models.spi.ParameterizedTypeDetails;
 import org.hibernate.models.spi.TypeDetails;
-import org.hibernate.models.spi.TypeVariableDetails;
-import org.hibernate.models.spi.TypeVariableReferenceDetails;
-import org.hibernate.models.spi.WildcardTypeDetails;
-
-import static org.hibernate.models.spi.StandardTypeDetails.OBJECT_TYPE_DETAILS;
+import org.hibernate.models.spi.TypeDetailsHelper;
 
 /**
- * Used to determine the type details for a Map value - see {@linkplain #extractMapValueType(TypeDetails)}
+ * Compatibility bridge for map value type extraction.
  *
- * @author Steve Ebersole
+ * @deprecated Use {@link TypeDetailsHelper#extractMapValueType(TypeDetails)}.
  */
-public class MapValueSwitch extends TypeDetailsSwitchSupport<TypeDetails> {
+@Deprecated(since = "1.1", forRemoval = true)
+public class MapValueSwitch {
+	private MapValueSwitch() {
+	}
 
 	public static TypeDetails extractMapValueType(TypeDetails memberType) {
-		assert memberType.isImplementor( Map.class );
-
-		final ClassDetails rawClassDetails = memberType.determineRawClass();
-		final MapValueSwitch mapValueSwitch = new MapValueSwitch( memberType );
-
-		// first, check super-type...
-		if ( rawClassDetails.getGenericSuperType() != null ) {
-			final TypeDetails typeDetails = TypeDetailsSwitcher.switchType( rawClassDetails.getGenericSuperType(), mapValueSwitch );
-			if ( typeDetails != null ) {
-				return typeDetails;
-			}
-		}
-
-		// then, interfaces...
-		for ( TypeDetails implementedInterface : rawClassDetails.getImplementedInterfaces() ) {
-			final TypeDetails typeDetails = TypeDetailsSwitcher.switchType( implementedInterface, mapValueSwitch );
-			if ( typeDetails != null ) {
-				return typeDetails;
-			}
-		}
-
-		// otherwise, assume Object
-		return OBJECT_TYPE_DETAILS;
-	}
-
-	private final TypeDetails memberTypeDetails;
-
-	private MapValueSwitch(TypeDetails memberTypeDetails) {
-		this.memberTypeDetails = memberTypeDetails;
-	}
-
-	@Override
-	public TypeDetails caseClass(ClassTypeDetails classType) {
-		if ( classType.isImplementor( Map.class ) ) {
-			if ( classType.getClassDetails().getGenericSuperType() != null ) {
-				return TypeDetailsSwitcher.switchType( classType.getClassDetails().getGenericSuperType(), this );
-			}
-		}
-		return null;
-	}
-
-	@Override
-	public TypeDetails caseParameterizedType(ParameterizedTypeDetails parameterizedType) {
-		if ( parameterizedType.isImplementor( Map.class ) ) {
-			return parameterizedType.getArguments().get( 1 );
-		}
-		return null;
-	}
-
-	@Override
-	public TypeDetails caseWildcardType(WildcardTypeDetails wildcardType) {
-		if ( wildcardType.isImplementor( Map.class ) ) {
-			return wildcardType.getBound();
-		}
-		return null;
-	}
-
-	@Override
-	public TypeDetails caseTypeVariable(TypeVariableDetails typeVariable) {
-		if ( typeVariable.isImplementor( Map.class ) ) {
-			return memberTypeDetails.resolveTypeVariable( typeVariable );
-		}
-		return null;
-	}
-
-	@Override
-	public TypeDetails caseTypeVariableReference(TypeVariableReferenceDetails typeVariableReference) {
-		if ( typeVariableReference.isImplementor( Map.class ) ) {
-			return memberTypeDetails.resolveTypeVariable( typeVariableReference.getTarget() );
-		}
-		return null;
+		return TypeDetailsHelper.extractMapValueType( memberType );
 	}
 }

--- a/hibernate-models/src/main/java/org/hibernate/models/spi/MemberDetails.java
+++ b/hibernate-models/src/main/java/org/hibernate/models/spi/MemberDetails.java
@@ -5,12 +5,6 @@
 package org.hibernate.models.spi;
 
 import java.lang.reflect.Member;
-import java.util.Collection;
-import java.util.Map;
-
-import org.hibernate.models.internal.CollectionElementSwitch;
-import org.hibernate.models.internal.MapKeySwitch;
-import org.hibernate.models.internal.MapValueSwitch;
 import org.hibernate.models.internal.ModifierUtils;
 
 /**
@@ -61,50 +55,7 @@ public interface MemberDetails extends AnnotationTarget {
 	 * For maps, the value type is returned.
 	 */
 	default TypeDetails getElementType() {
-		final TypeDetails memberType = getType();
-		if ( memberType == null ) {
-			return null;
-		}
-
-		if ( memberType.getTypeKind() == TypeDetails.Kind.ARRAY ) {
-			return memberType.asArrayType().getConstituentType();
-		}
-
-		if ( memberType.isImplementor( Collection.class ) ) {
-			if ( memberType.getTypeKind() == TypeDetails.Kind.CLASS ) {
-				// handle "concrete types" such as `class SpecialList implements List<String>`
-				return CollectionElementSwitch.extractCollectionElementType( memberType );
-			}
-			if ( memberType.getTypeKind() == TypeDetails.Kind.PARAMETERIZED_TYPE ) {
-				final ParameterizedTypeDetails parameterizedType = memberType.asParameterizedType();
-				assert parameterizedType.getArguments().size() == 1;
-				return parameterizedType.getArguments().get( 0 );
-			}
-			if ( memberType.getTypeKind() == TypeDetails.Kind.TYPE_VARIABLE ) {
-				final TypeVariableDetails typeVariable = memberType.asTypeVariable();
-				assert typeVariable.getBounds().size() == 1;
-				return typeVariable.getBounds().get( 0 );
-			}
-		}
-
-		if ( memberType.isImplementor( Map.class ) ) {
-			if ( memberType.getTypeKind() == TypeDetails.Kind.CLASS ) {
-				// handle "concrete types" such as `class SpecialMap implements Map<String,String>`
-				return MapValueSwitch.extractMapValueType( memberType );
-			}
-			if ( memberType.getTypeKind() == TypeDetails.Kind.PARAMETERIZED_TYPE ) {
-				final ParameterizedTypeDetails parameterizedType = memberType.asParameterizedType();
-				assert parameterizedType.getArguments().size() == 2;
-				return parameterizedType.getArguments().get( 1 );
-			}
-			if ( memberType.getTypeKind() == TypeDetails.Kind.TYPE_VARIABLE ) {
-				final TypeVariableDetails typeVariable = memberType.asTypeVariable();
-				assert typeVariable.getBounds().size() == 2;
-				return typeVariable.getBounds().get( 1 );
-			}
-		}
-
-		return null;
+		return TypeDetailsHelper.extractElementType( getType() );
 	}
 
 	/**
@@ -113,28 +64,9 @@ public interface MemberDetails extends AnnotationTarget {
 	 */
 	default TypeDetails getMapKeyType() {
 		final TypeDetails memberType = getType();
-		if ( memberType == null ) {
-			return null;
-		}
-
-		if ( memberType.isImplementor( Map.class ) ) {
-			if ( memberType.getTypeKind() == TypeDetails.Kind.CLASS ) {
-				// handle "concrete types" such as `class SpecialMap implements Map<String,String>`
-				return MapKeySwitch.extractMapKeyType( memberType );
-			}
-			if ( memberType.getTypeKind() == TypeDetails.Kind.PARAMETERIZED_TYPE ) {
-				final ParameterizedTypeDetails parameterizedType = memberType.asParameterizedType();
-				assert parameterizedType.getArguments().size() == 2;
-				return parameterizedType.getArguments().get( 0 );
-			}
-			if ( memberType.getTypeKind() == TypeDetails.Kind.TYPE_VARIABLE ) {
-				final TypeVariableDetails typeVariable = memberType.asTypeVariable();
-				assert typeVariable.getBounds().size() == 2;
-				return typeVariable.getBounds().get( 0 );
-			}
-		}
-
-		return null;
+		return memberType == null || !memberType.isImplementor( java.util.Map.class )
+				? null
+				: TypeDetailsHelper.extractMapKeyType( memberType );
 	}
 
 	/**

--- a/hibernate-models/src/main/java/org/hibernate/models/spi/TypeDetailsHelper.java
+++ b/hibernate-models/src/main/java/org/hibernate/models/spi/TypeDetailsHelper.java
@@ -9,8 +9,12 @@ import org.hibernate.models.internal.ParameterizedTypeDetailsImpl;
 import org.hibernate.models.internal.PrimitiveKind;
 import org.hibernate.models.internal.util.CollectionHelper;
 
+import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.hibernate.models.internal.util.CollectionHelper.arrayList;
 import static org.hibernate.models.spi.StandardTypeDetails.OBJECT_TYPE_DETAILS;
@@ -21,6 +25,110 @@ import static org.hibernate.models.spi.StandardTypeDetails.OBJECT_TYPE_DETAILS;
  * @author Steve Ebersole
  */
 public class TypeDetailsHelper {
+	/**
+	 * Resolve {@code type} to the corresponding occurrence of {@code superType} in its
+	 * type hierarchy, substituting type variables at each hierarchy edge.
+	 *
+	 * @return the resolved super type, or {@code null} if {@code type} does not implement it
+	 */
+	public static TypeDetails resolveSuperType(TypeDetails type, Class<?> superType) {
+		if ( type == null || !type.isImplementor( superType ) ) {
+			return null;
+		}
+		return resolveSuperType( type, superType, new HashSet<>() );
+	}
+
+	private static TypeDetails resolveSuperType(
+			TypeDetails type,
+			Class<?> superType,
+			Set<ClassDetails> visitedTypes) {
+		if ( type.getTypeKind() == TypeDetails.Kind.WILDCARD_TYPE ) {
+			final TypeDetails bound = type.asWildcardType().getBound();
+			return bound == null ? null : resolveSuperType( bound, superType, visitedTypes );
+		}
+		if ( type.getTypeKind() == TypeDetails.Kind.TYPE_VARIABLE ) {
+			for ( TypeDetails bound : type.asTypeVariable().getBounds() ) {
+				final TypeDetails resolved = resolveSuperType( bound, superType, visitedTypes );
+				if ( resolved != null ) {
+					return resolved;
+				}
+			}
+			return null;
+		}
+
+		final ClassDetails rawType = type.determineRawClass();
+		if ( rawType.getName().equals( superType.getName() ) ) {
+			return type;
+		}
+		if ( !visitedTypes.add( rawType ) ) {
+			return null;
+		}
+
+		final TypeDetails genericSuperType = rawType.getGenericSuperType();
+		if ( genericSuperType != null ) {
+			final TypeDetails resolved = resolveSuperType(
+					genericSuperType.determineRelativeType( type ),
+					superType,
+					visitedTypes
+			);
+			if ( resolved != null ) {
+				return resolved;
+			}
+		}
+
+		for ( TypeDetails implementedInterface : rawType.getImplementedInterfaces() ) {
+			final TypeDetails resolved = resolveSuperType(
+					implementedInterface.determineRelativeType( type ),
+					superType,
+					visitedTypes
+			);
+			if ( resolved != null ) {
+				return resolved;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Extract the collection element or map value type.
+	 */
+	public static TypeDetails extractElementType(TypeDetails type) {
+		if ( type == null ) {
+			return null;
+		}
+		if ( type.getTypeKind() == TypeDetails.Kind.ARRAY ) {
+			return type.asArrayType().getConstituentType();
+		}
+		if ( type.isImplementor( Collection.class ) ) {
+			return extractCollectionElementType( type );
+		}
+		if ( type.isImplementor( Map.class ) ) {
+			return extractMapValueType( type );
+		}
+		return null;
+	}
+
+	public static TypeDetails extractCollectionElementType(TypeDetails type) {
+		return extractTypeArgument( resolveSuperType( type, Collection.class ), 0 );
+	}
+
+	public static TypeDetails extractMapKeyType(TypeDetails type) {
+		return extractTypeArgument( resolveSuperType( type, Map.class ), 0 );
+	}
+
+	public static TypeDetails extractMapValueType(TypeDetails type) {
+		return extractTypeArgument( resolveSuperType( type, Map.class ), 1 );
+	}
+
+	private static TypeDetails extractTypeArgument(TypeDetails resolvedType, int argumentIndex) {
+		if ( resolvedType == null || resolvedType.getTypeKind() != TypeDetails.Kind.PARAMETERIZED_TYPE ) {
+			return OBJECT_TYPE_DETAILS;
+		}
+		final List<TypeDetails> arguments = resolvedType.asParameterizedType().getArguments();
+		return argumentIndex < arguments.size() ? arguments.get( argumentIndex ) : OBJECT_TYPE_DETAILS;
+	}
+
 	/**
 	 * Given an attribute member type and a concrete container type, resolve the type of
 	 * the attribute relative to that container.

--- a/hibernate-models/src/test/java/org/hibernate/models/testing/tests/generics/CollectionTests.java
+++ b/hibernate-models/src/test/java/org/hibernate/models/testing/tests/generics/CollectionTests.java
@@ -5,6 +5,7 @@
 package org.hibernate.models.testing.tests.generics;
 
 import java.util.ArrayList;
+import java.util.AbstractMap;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -319,6 +320,46 @@ public class CollectionTests {
 		assertThat( superSpecialHashMapField.getElementType().determineRawClass().toJavaClass() ).isEqualTo( String.class );
 	}
 
+	@Test
+	@SuppressWarnings("removal")
+	void testMapSubtypeArgumentResolution() {
+		final ModelsContext modelsContext = createModelContext(
+				GenericStringMap.class,
+				JsonPayload.class,
+				IntermediateMap.class,
+				ReversedMap.class,
+				StringKeyedMap.class,
+				GenericMapContainer.class
+		);
+		final ClassDetails container = modelsContext.getClassDetailsRegistry()
+				.getClassDetails( GenericMapContainer.class.getName() );
+
+		assertMapArguments( container.findFieldByName( "payload" ), String.class, Object.class );
+		assertMapArguments( container.findFieldByName( "integerValues" ), String.class, Integer.class );
+		assertMapArguments( container.findFieldByName( "longValues" ), String.class, Long.class );
+		assertMapArguments( container.findFieldByName( "reversed" ), String.class, Integer.class );
+		assertMapArguments( container.findFieldByName( "interfaceMap" ), String.class, Double.class );
+		assertMapArguments( container.findFieldByName( "rawValues" ), String.class, Object.class );
+
+		final TypeDetails resolvedMapType = org.hibernate.models.spi.TypeDetailsHelper.resolveSuperType(
+				container.findFieldByName( "longValues" ).getType(),
+				Map.class
+		);
+		assertThat( resolvedMapType ).isInstanceOf( ParameterizedTypeDetails.class );
+		assertThat( resolvedMapType.asParameterizedType().getRawClassDetails().toJavaClass() ).isEqualTo( Map.class );
+
+		final TypeDetails payloadType = container.findFieldByName( "payload" ).getType();
+		assertThat( org.hibernate.models.internal.MapKeySwitch.extractMapKeyType( payloadType )
+				.determineRawClass().toJavaClass() ).isEqualTo( String.class );
+		assertThat( org.hibernate.models.internal.MapValueSwitch.extractMapValueType( payloadType )
+				.determineRawClass().toJavaClass() ).isEqualTo( Object.class );
+	}
+
+	private static void assertMapArguments(FieldDetails field, Class<?> keyType, Class<?> valueType) {
+		assertThat( field.getMapKeyType().determineRawClass().toJavaClass() ).isEqualTo( keyType );
+		assertThat( field.getElementType().determineRawClass().toJavaClass() ).isEqualTo( valueType );
+	}
+
 
 	@SuppressWarnings("unused")
 	static class ClassOfCollections<T> {
@@ -509,6 +550,35 @@ public class CollectionTests {
 	}
 
 	static class SuperSpecialHashMap extends SpecialHashMap {
+	}
+
+	abstract static class GenericStringMap<V> extends AbstractMap<String, V> {
+	}
+
+	static class JsonPayload extends GenericStringMap<Object> {
+		@Override
+		public Set<Entry<String, Object>> entrySet() {
+			return Set.of();
+		}
+	}
+
+	abstract static class IntermediateMap<T> extends GenericStringMap<T> {
+	}
+
+	abstract static class ReversedMap<A, B> extends AbstractMap<B, A> {
+	}
+
+	interface StringKeyedMap<V> extends Map<String, V> {
+	}
+
+	@SuppressWarnings({"unused", "rawtypes"})
+	static class GenericMapContainer {
+		JsonPayload payload;
+		GenericStringMap<Integer> integerValues;
+		IntermediateMap<Long> longValues;
+		ReversedMap<Integer, String> reversed;
+		StringKeyedMap<Double> interfaceMap;
+		GenericStringMap rawValues;
 	}
 
 


### PR DESCRIPTION
#263 - Resolve collection and map type arguments through generic type hierarchies

Added a new `TypeDetailsHelper.resolveSuperType(...)` method which, recursively:

1. Traverses generic superclasses and interfaces.
2. Substitutes type variables at every hierarchy edge.
3. Returns the resolved occurrence of the requested super-type.

Collection/map type extraction now delegates through that resolver.  Longer term we can use that for other resolutions such as `AttributeConverter`, etc.